### PR TITLE
Add themed SummitPM subpages

### DIFF
--- a/public/contact.html
+++ b/public/contact.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact | Summit Property Management</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-page="contact">
+    <header class="hero page-hero">
+      <nav class="navbar">
+        <a class="logo" href="index.html">Summit<span>PM</span></a>
+        <ul class="nav-links">
+          <li><a href="index.html" data-page="home">Home</a></li>
+          <li><a href="services.html" data-page="services">Services</a></li>
+          <li><a href="portfolio.html" data-page="portfolio">Portfolio</a></li>
+          <li>
+            <a href="testimonials.html" data-page="testimonials">Testimonials</a>
+          </li>
+          <li><a href="contact.html" data-page="contact">Contact</a></li>
+        </ul>
+        <a href="contact.html" class="btn btn-outline">Request Proposal</a>
+      </nav>
+      <div class="hero-content">
+        <div class="hero-text">
+          <span class="eyebrow">Let's Collaborate</span>
+          <h1>Connect with SummitPM's asset strategists</h1>
+          <p>
+            Share your vision for the next landmark property. We'll assemble the
+            right experts to build a bespoke management roadmap.
+          </p>
+          <div class="hero-actions">
+            <a href="#connect" class="btn btn-primary">Schedule a Call</a>
+            <a href="tel:+13125550198" class="btn btn-ghost">Call +1 (312) 555-0198</a>
+          </div>
+        </div>
+        <div class="hero-stats">
+          <div class="stat-card">
+            <h3>24/7</h3>
+            <p>Concierge response for residents and owners</p>
+          </div>
+          <div class="stat-card">
+            <h3>3 hrs</h3>
+            <p>Average turnaround for owner insights requests</p>
+          </div>
+          <div class="stat-card">
+            <h3>5 Cities</h3>
+            <p>Regional experience centers nationwide</p>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="section" id="connect">
+        <div class="section-split">
+          <div>
+            <span class="eyebrow">Contact</span>
+            <h2>Tell us about your property goals</h2>
+            <p>
+              Whether you’re launching a flagship residence or repositioning a
+              legacy tower, we’ll craft a tailored plan aligned with your brand,
+              residents, and investors.
+            </p>
+            <div class="contact-grid">
+              <div class="contact-card">
+                <h4>Visit</h4>
+                <p>123 Skyline Avenue, Suite 1800<br />Chicago, IL 60601</p>
+              </div>
+              <div class="contact-card">
+                <h4>Email</h4>
+                <a href="mailto:hello@summitpm.com">hello@summitpm.com</a>
+              </div>
+              <div class="contact-card">
+                <h4>Phone</h4>
+                <a href="tel:+13125550198">+1 (312) 555-0198</a>
+              </div>
+            </div>
+          </div>
+          <form class="contact-form">
+            <div class="form-row">
+              <input type="text" name="name" placeholder="Full Name" required />
+              <input type="email" name="email" placeholder="Email Address" required />
+            </div>
+            <div class="form-row">
+              <input type="text" name="company" placeholder="Company" />
+              <input type="tel" name="phone" placeholder="Phone" />
+            </div>
+            <textarea
+              name="message"
+              rows="5"
+              placeholder="Share the scope, timeline, and goals for your property"
+            ></textarea>
+            <button type="submit" class="btn btn-primary">Request Consultation</button>
+          </form>
+        </div>
+      </section>
+
+      <section class="section section-dark">
+        <div class="section-split">
+          <div>
+            <span class="eyebrow">Regional Presence</span>
+            <h2>Experience centers across the country</h2>
+            <p>
+              Our strategists host immersive workshops in each of our hubs,
+              bringing your team together with designers, technologists, and
+              operations leaders.
+            </p>
+          </div>
+          <div class="pill-grid">
+            <div class="pill-card">
+              <h4>Chicago</h4>
+              <p>Headquarters and innovation lab overlooking the river.</p>
+            </div>
+            <div class="pill-card">
+              <h4>New York</h4>
+              <p>Luxury residential war room in Midtown South.</p>
+            </div>
+            <div class="pill-card">
+              <h4>Los Angeles</h4>
+              <p>Hospitality programming studio in the Arts District.</p>
+            </div>
+            <div class="pill-card">
+              <h4>Miami</h4>
+              <p>Coastal lifestyle command center in Brickell.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <span class="eyebrow">FAQs</span>
+          <h2>Answers to common partnership questions</h2>
+          <p>
+            Preparing for a conversation? These highlights outline how we begin
+            collaborations.
+          </p>
+        </div>
+        <div class="faq-grid">
+          <div class="faq-item">
+            <h4>What types of assets do you manage?</h4>
+            <p>
+              We partner with luxury residential towers, mixed-use destinations,
+              and high-touch commercial properties seeking elevated service.
+            </p>
+          </div>
+          <div class="faq-item">
+            <h4>How quickly can you transition a property?</h4>
+            <p>
+              Our transition task force mobilizes within ten days and delivers a
+              detailed 90-day roadmap aligned with your ownership goals.
+            </p>
+          </div>
+          <div class="faq-item">
+            <h4>Do you offer consulting-only engagements?</h4>
+            <p>
+              Yes. Advisory sprints and technology roadmapping are available as
+              standalone services or as part of a broader management program.
+            </p>
+          </div>
+          <div class="faq-item">
+            <h4>How do we start the conversation?</h4>
+            <p>
+              Submit the form above or call our team. We’ll schedule a discovery
+              session to understand your asset, timeline, and success metrics.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="footer-content">
+        <div>
+          <div class="logo">Summit<span>PM</span></div>
+          <p>
+            Boutique property management partners crafting elevated experiences
+            for residents, tenants, and owners.
+          </p>
+        </div>
+        <div class="footer-links">
+          <a href="services.html">Services</a>
+          <a href="portfolio.html">Portfolio</a>
+          <a href="testimonials.html">Testimonials</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <div class="footer-contact">
+          <p>hello@summitpm.com</p>
+          <p>+1 (312) 555-0198</p>
+          <p>123 Skyline Avenue, Suite 1800, Chicago, IL</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Summit Property Management. All rights reserved.</p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -12,17 +12,20 @@
     />
     <link rel="stylesheet" href="styles.css" />
   </head>
-  <body>
+  <body data-page="home">
     <header class="hero">
       <nav class="navbar">
-        <div class="logo">Summit<span>PM</span></div>
+        <a class="logo" href="index.html">Summit<span>PM</span></a>
         <ul class="nav-links">
-          <li><a href="#services">Services</a></li>
-          <li><a href="#portfolio">Portfolio</a></li>
-          <li><a href="#testimonials">Testimonials</a></li>
-          <li><a href="#contact">Contact</a></li>
+          <li><a href="index.html" data-page="home">Home</a></li>
+          <li><a href="services.html" data-page="services">Services</a></li>
+          <li><a href="portfolio.html" data-page="portfolio">Portfolio</a></li>
+          <li>
+            <a href="testimonials.html" data-page="testimonials">Testimonials</a>
+          </li>
+          <li><a href="contact.html" data-page="contact">Contact</a></li>
         </ul>
-        <a href="#contact" class="btn btn-outline">Request Proposal</a>
+        <a href="contact.html" class="btn btn-outline">Request Proposal</a>
       </nav>
       <div class="hero-content">
         <div class="hero-text">
@@ -33,8 +36,8 @@
             and visionary design.
           </p>
           <div class="hero-actions">
-            <a href="#services" class="btn btn-primary">Explore Services</a>
-            <a href="#portfolio" class="btn btn-ghost">View Portfolio</a>
+            <a href="services.html" class="btn btn-primary">Explore Services</a>
+            <a href="portfolio.html" class="btn btn-ghost">View Portfolio</a>
           </div>
         </div>
         <div class="hero-stats">
@@ -259,10 +262,10 @@
           </p>
         </div>
         <div class="footer-links">
-          <a href="#services">Services</a>
-          <a href="#portfolio">Portfolio</a>
-          <a href="#testimonials">Testimonials</a>
-          <a href="#contact">Contact</a>
+          <a href="services.html">Services</a>
+          <a href="portfolio.html">Portfolio</a>
+          <a href="testimonials.html">Testimonials</a>
+          <a href="contact.html">Contact</a>
         </div>
         <div class="footer-contact">
           <p>hello@summitpm.com</p>

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portfolio | Summit Property Management</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-page="portfolio">
+    <header class="hero page-hero">
+      <nav class="navbar">
+        <a class="logo" href="index.html">Summit<span>PM</span></a>
+        <ul class="nav-links">
+          <li><a href="index.html" data-page="home">Home</a></li>
+          <li><a href="services.html" data-page="services">Services</a></li>
+          <li><a href="portfolio.html" data-page="portfolio">Portfolio</a></li>
+          <li>
+            <a href="testimonials.html" data-page="testimonials">Testimonials</a>
+          </li>
+          <li><a href="contact.html" data-page="contact">Contact</a></li>
+        </ul>
+        <a href="contact.html" class="btn btn-outline">Request Proposal</a>
+      </nav>
+      <div class="hero-content">
+        <div class="hero-text">
+          <span class="eyebrow">Our Work</span>
+          <h1>Signature transformations that redefine skyline living</h1>
+          <p>
+            Explore a cross-section of luxury residences and commercial towers
+            elevated through SummitPM stewardship, innovation, and lifestyle
+            programming.
+          </p>
+          <div class="hero-actions">
+            <a href="#case-studies" class="btn btn-primary">View Case Studies</a>
+            <a href="services.html" class="btn btn-ghost">See Our Services</a>
+          </div>
+        </div>
+        <div class="hero-stats">
+          <div class="stat-card">
+            <h3>92%</h3>
+            <p>Average tenant retention across managed assets</p>
+          </div>
+          <div class="stat-card">
+            <h3>18</h3>
+            <p>Adaptive reuse projects repositioned since 2020</p>
+          </div>
+          <div class="stat-card">
+            <h3>4.9</h3>
+            <p>Resident review score across the portfolio</p>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="section" id="case-studies">
+        <div class="page-intro">
+          <span class="eyebrow">Case Studies</span>
+          <h2>From legacy towers to boutique residences</h2>
+          <p>
+            Each engagement combines operational rigor with immersive brand
+            storytelling to create destinations residents are proud to call home.
+          </p>
+        </div>
+        <div class="grid case-study-grid">
+          <article class="card case-study-card">
+            <div class="card-image">
+              <img
+                src="https://images.unsplash.com/photo-1529429617124-aee0a9429e5a?auto=format&fit=crop&w=1200&q=80"
+                alt="Nexus Tower lobby"
+              />
+            </div>
+            <div class="card-body">
+              <div class="tag-row">
+                <span class="tag">Commercial</span>
+                <span class="tag">Smart Access</span>
+              </div>
+              <h3>Nexus Tower</h3>
+              <p>
+                Repositioned Class A office destination with biophilic design,
+                curated dining, and a digital-first tenant journey.
+              </p>
+              <ul class="card-list">
+                <li>36% increase in premium lease renewals</li>
+                <li>Integrated workplace app driving 82% adoption</li>
+                <li>Lobby activation program boosting foot traffic</li>
+              </ul>
+            </div>
+          </article>
+          <article class="card case-study-card">
+            <div class="card-image">
+              <img
+                src="https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80"
+                alt="Aurum Residences rooftop"
+              />
+            </div>
+            <div class="card-body">
+              <div class="tag-row">
+                <span class="tag">Residential</span>
+                <span class="tag">Wellness</span>
+              </div>
+              <h3>Aurum Residences</h3>
+              <p>
+                Flagship penthouse community with bespoke wellness amenities and
+                hospitality-style resident services.
+              </p>
+              <ul class="card-list">
+                <li>Sold-out penthouse collection in six weeks</li>
+                <li>Curated wellness partnerships elevating retention</li>
+                <li>Net promoter score lifted by 34 points</li>
+              </ul>
+            </div>
+          </article>
+          <article class="card case-study-card">
+            <div class="card-image">
+              <img
+                src="https://images.unsplash.com/photo-1505843513577-22bb7d21e455?auto=format&fit=crop&w=1200&q=80"
+                alt="Harborfront Lofts exterior"
+              />
+            </div>
+            <div class="card-body">
+              <div class="tag-row">
+                <span class="tag">Adaptive Reuse</span>
+                <span class="tag">Community</span>
+              </div>
+              <h3>Harborfront Lofts</h3>
+              <p>
+                Waterfront loft conversions blending heritage architecture with
+                elevated concierge and social programming.
+              </p>
+              <ul class="card-list">
+                <li>98% occupancy maintained during renovation</li>
+                <li>Local artisan marketplace hosted quarterly</li>
+                <li>Energy consumption reduced by 21%</li>
+              </ul>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="section highlight">
+        <div class="highlight-text">
+          <span class="eyebrow">Signature Moments</span>
+          <h2>Immersive spaces crafted for connection</h2>
+          <p>
+            Our design and lifestyle teams collaborate with global partners to
+            curate art, wellness, and culinary experiences that keep residents
+            engaged year-round.
+          </p>
+          <ul class="feature-list">
+            <li>Artist-in-residence programs and rotating galleries</li>
+            <li>Seasonal rooftop retreats with bespoke culinary concepts</li>
+            <li>Wellness studios featuring leading performance partners</li>
+          </ul>
+        </div>
+        <div class="highlight-gallery">
+          <div class="gallery-item large">
+            <img
+              src="https://images.unsplash.com/photo-1529429617124-aee0a9429e5a?auto=format&fit=crop&w=1600&q=80"
+              alt="Curated lounge"
+            />
+          </div>
+          <div class="gallery-item">
+            <img
+              src="https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?auto=format&fit=crop&w=800&q=80"
+              alt="Resident lounge"
+            />
+          </div>
+          <div class="gallery-item">
+            <img
+              src="https://images.unsplash.com/photo-1505843513577-22bb7d21e455?auto=format&fit=crop&w=800&q=80"
+              alt="Skyline pool"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-split">
+          <div>
+            <span class="eyebrow">Performance Metrics</span>
+            <h2>Data-backed outcomes owners rely on</h2>
+            <p>
+              Each project includes a bespoke analytics dashboard with the KPIs
+              that matter most—from NOI lift to engagement scores—so you always
+              have a clear view of performance.
+            </p>
+            <a href="contact.html" class="btn btn-primary">Request a Portfolio Review</a>
+          </div>
+          <div class="metrics-grid">
+            <div class="metric-card">
+              <h3>+19%</h3>
+              <p>Average rent growth in repositioned assets</p>
+            </div>
+            <div class="metric-card">
+              <h3>12 Weeks</h3>
+              <p>Typical timeline to complete rebrand and launch</p>
+            </div>
+            <div class="metric-card">
+              <h3>84%</h3>
+              <p>Residents engaged in loyalty and events programming</p>
+            </div>
+            <div class="metric-card">
+              <h3>Zero</h3>
+              <p>Unplanned downtime events across mission-critical systems</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="footer-content">
+        <div>
+          <div class="logo">Summit<span>PM</span></div>
+          <p>
+            Boutique property management partners crafting elevated experiences
+            for residents, tenants, and owners.
+          </p>
+        </div>
+        <div class="footer-links">
+          <a href="services.html">Services</a>
+          <a href="portfolio.html">Portfolio</a>
+          <a href="testimonials.html">Testimonials</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <div class="footer-contact">
+          <p>hello@summitpm.com</p>
+          <p>+1 (312) 555-0198</p>
+          <p>123 Skyline Avenue, Suite 1800, Chicago, IL</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Summit Property Management. All rights reserved.</p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -4,8 +4,17 @@ document.addEventListener('DOMContentLoaded', () => {
     yearEl.textContent = new Date().getFullYear();
   }
 
-  const navLinks = document.querySelectorAll('a[href^="#"]');
+  const navLinks = document.querySelectorAll('.nav-links a');
+  const activePage = document.body.dataset.page;
+
   navLinks.forEach((link) => {
+    if (link.dataset.page === activePage) {
+      link.classList.add('active');
+    }
+  });
+
+  const anchorLinks = document.querySelectorAll('a[href^="#"]');
+  anchorLinks.forEach((link) => {
     link.addEventListener('click', (event) => {
       const targetId = link.getAttribute('href').substring(1);
       const target = document.getElementById(targetId);

--- a/public/services.html
+++ b/public/services.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Services | Summit Property Management</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-page="services">
+    <header class="hero page-hero">
+      <nav class="navbar">
+        <a class="logo" href="index.html">Summit<span>PM</span></a>
+        <ul class="nav-links">
+          <li><a href="index.html" data-page="home">Home</a></li>
+          <li><a href="services.html" data-page="services">Services</a></li>
+          <li><a href="portfolio.html" data-page="portfolio">Portfolio</a></li>
+          <li>
+            <a href="testimonials.html" data-page="testimonials">Testimonials</a>
+          </li>
+          <li><a href="contact.html" data-page="contact">Contact</a></li>
+        </ul>
+        <a href="contact.html" class="btn btn-outline">Request Proposal</a>
+      </nav>
+      <div class="hero-content">
+        <div class="hero-text">
+          <span class="eyebrow">Our Expertise</span>
+          <h1>Comprehensive property management tailored to your portfolio</h1>
+          <p>
+            We pair hospitality-trained teams with enterprise-grade operations to
+            protect your asset, delight residents, and outperform the market at
+            every turn.
+          </p>
+          <div class="hero-actions">
+            <a href="#service-suite" class="btn btn-primary">Our Service Suite</a>
+            <a href="contact.html" class="btn btn-ghost">Meet Your Team</a>
+          </div>
+        </div>
+        <div class="hero-stats">
+          <div class="stat-card">
+            <h3>38</h3>
+            <p>Specialists dedicated to daily property operations</p>
+          </div>
+          <div class="stat-card">
+            <h3>27%</h3>
+            <p>Average NOI lift after our first 12 months on-site</p>
+          </div>
+          <div class="stat-card">
+            <h3>5</h3>
+            <p>Regional hubs delivering on-demand expertise</p>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="section" id="service-suite">
+        <div class="page-intro">
+          <span class="eyebrow">Service Suite</span>
+          <h2>Full-spectrum management for iconic destinations</h2>
+          <p>
+            From lease-up through lifestyle programming, our team integrates
+            technology, design, and hospitality thinking to orchestrate
+            unforgettable living and working experiences.
+          </p>
+        </div>
+        <div class="grid services-grid">
+          <article class="card service-card">
+            <div class="card-image">
+              <img
+                src="https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?auto=format&fit=crop&w=900&q=80"
+                alt="Luxury lobby"
+              />
+            </div>
+            <div class="card-body">
+              <h3>Operations & Resident Experience</h3>
+              <p>
+                Hospitality-led concierge and community teams curate effortless
+                living with white-glove coordination.
+              </p>
+              <ul class="card-list">
+                <li>Concierge staffing, scheduling, and training</li>
+                <li>Smart building integrations & mobile experiences</li>
+                <li>Programming for wellness, culture, and events</li>
+              </ul>
+            </div>
+          </article>
+          <article class="card service-card">
+            <div class="card-image">
+              <img
+                src="https://images.unsplash.com/photo-1449157291145-7efd050a4d0e?auto=format&fit=crop&w=900&q=80"
+                alt="Modern office building"
+              />
+            </div>
+            <div class="card-body">
+              <h3>Asset & Financial Strategy</h3>
+              <p>
+                Transparent reporting, predictive analytics, and thoughtful
+                capital planning engineered for growth.
+              </p>
+              <ul class="card-list">
+                <li>Owner dashboards updated in real time</li>
+                <li>Capital expenditure modeling and oversight</li>
+                <li>Strategic leasing and revenue optimization</li>
+              </ul>
+            </div>
+          </article>
+          <article class="card service-card">
+            <div class="card-image">
+              <img
+                src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=900&q=80"
+                alt="Sustainable rooftop garden"
+              />
+            </div>
+            <div class="card-body">
+              <h3>Facilities & Sustainability</h3>
+              <p>
+                Proactive maintenance programs centered on longevity and
+                sustainable performance.
+              </p>
+              <ul class="card-list">
+                <li>Preventative maintenance and vendor management</li>
+                <li>Energy benchmarking and green certification</li>
+                <li>Emergency readiness and risk mitigation plans</li>
+              </ul>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="section section-dark">
+        <div class="section-split">
+          <div>
+            <span class="eyebrow">How We Deliver</span>
+            <h2>Specialized launch teams for every stage of the journey</h2>
+            <p>
+              Cross-functional experts assemble for each engagement, guiding your
+              assets through acquisition, repositioning, and long-term
+              stewardship with precision.
+            </p>
+            <ul class="feature-list">
+              <li>Dedicated transition task force on-site within 10 days</li>
+              <li>Integrated leasing, marketing, and lifestyle pods</li>
+              <li>Quarterly innovation labs to pilot resident amenities</li>
+            </ul>
+          </div>
+          <div class="pill-grid">
+            <div class="pill-card">
+              <h4>Lease-Up Launch</h4>
+              <p>
+                Amenity programming, brand voice development, and digital
+                campaigns engineered for rapid absorption.
+              </p>
+            </div>
+            <div class="pill-card">
+              <h4>Stabilized Excellence</h4>
+              <p>
+                Daily experience audits, sentiment tracking, and community
+                activations that keep occupancy at record levels.
+              </p>
+            </div>
+            <div class="pill-card">
+              <h4>Asset Repositioning</h4>
+              <p>
+                Scenario modeling, capital planning, and design partnerships that
+                reimagine underperforming properties.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <span class="eyebrow">Advisory Programs</span>
+          <h2>Embedded strategists to future-proof your portfolio</h2>
+          <p>
+            Access the executive advisory bench that owners rely on for due
+            diligence, market entry, and operational transformation.
+          </p>
+        </div>
+        <div class="grid advisory-grid">
+          <div class="advisory-card">
+            <h4>Market Intelligence Sprints</h4>
+            <p>
+              Three-week deep dives deliver competitive positioning, renter
+              demand analysis, and actionable pricing strategies.
+            </p>
+          </div>
+          <div class="advisory-card">
+            <h4>Technology Roadmapping</h4>
+            <p>
+              Evaluate proptech stacks, identify integration wins, and implement
+              automation that elevates every touchpoint.
+            </p>
+          </div>
+          <div class="advisory-card">
+            <h4>Owner Representation</h4>
+            <p>
+              Senior team members serve as your advocates during development and
+              construction, aligning vendors with your brand vision.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="footer-content">
+        <div>
+          <div class="logo">Summit<span>PM</span></div>
+          <p>
+            Boutique property management partners crafting elevated experiences
+            for residents, tenants, and owners.
+          </p>
+        </div>
+        <div class="footer-links">
+          <a href="services.html">Services</a>
+          <a href="portfolio.html">Portfolio</a>
+          <a href="testimonials.html">Testimonials</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <div class="footer-contact">
+          <p>hello@summitpm.com</p>
+          <p>+1 (312) 555-0198</p>
+          <p>123 Skyline Avenue, Suite 1800, Chicago, IL</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Summit Property Management. All rights reserved.</p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -78,6 +78,10 @@ img {
   position: relative;
 }
 
+.nav-links a.active {
+  color: var(--primary);
+}
+
 .nav-links a::after {
   content: '';
   position: absolute;
@@ -94,6 +98,24 @@ img {
 .nav-links a:hover::after {
   transform: scaleX(1);
   transform-origin: left;
+}
+
+.nav-links a.active::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+.page-hero {
+  min-height: 70vh;
+  padding-block: clamp(4rem, 8vw, 6rem);
+}
+
+.page-hero .hero-content {
+  align-items: center;
+}
+
+.page-main {
+  background: var(--bg-light);
 }
 
 .btn {
@@ -185,6 +207,15 @@ img {
   padding: clamp(4rem, 8vw, 7rem) clamp(1.5rem, 6vw, 5rem);
 }
 
+.page-intro {
+  max-width: 760px;
+  margin-bottom: 3rem;
+}
+
+.page-intro p {
+  color: var(--text-muted);
+}
+
 .section-header {
   max-width: 720px;
   margin-bottom: 3rem;
@@ -249,6 +280,31 @@ img {
 
 .card-body p {
   color: var(--text-muted);
+}
+
+.card-list {
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 1.2rem;
+  color: var(--text-muted);
+}
+
+.card-list li {
+  position: relative;
+  padding-left: 1.4rem;
+}
+
+.card-list li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.55rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  box-shadow: 0 0 12px rgba(122, 201, 255, 0.6);
 }
 
 .highlight {
@@ -455,6 +511,168 @@ textarea:focus {
 .footer-bottom {
   font-size: 0.85rem;
   color: rgba(255, 255, 255, 0.45);
+}
+
+.section-dark {
+  background: #0b1322;
+  color: #fff;
+}
+
+.section-dark p {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.section-dark .feature-list li::before {
+  box-shadow: 0 0 18px rgba(247, 183, 51, 0.6);
+}
+
+.section-split {
+  display: grid;
+  gap: clamp(2rem, 5vw, 4rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.pill-grid {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.pill-card {
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text-main);
+  border-radius: 20px;
+  padding: 1.6rem;
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.section-dark .pill-card {
+  background: rgba(12, 21, 36, 0.9);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.25);
+}
+
+.advisory-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.advisory-card {
+  background: #fff;
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 0.8rem;
+}
+
+.case-study-grid {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.case-study-card .card-image img {
+  height: 240px;
+}
+
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.8rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(122, 201, 255, 0.18);
+  color: var(--text-main);
+}
+
+.metrics-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.metric-card {
+  background: #fff;
+  border-radius: 18px;
+  padding: 1.6rem;
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.metric-card h3 {
+  font-size: 1.8rem;
+}
+
+.logo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+}
+
+.logo-card {
+  background: #fff;
+  border-radius: 18px;
+  padding: 1.8rem;
+  text-align: center;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: var(--shadow-card);
+}
+
+.contact-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-top: 2rem;
+}
+
+.contact-card {
+  background: #fff;
+  border-radius: 18px;
+  padding: 1.4rem 1.6rem;
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.contact-card a {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.faq-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.faq-item {
+  background: #fff;
+  border-radius: 18px;
+  padding: 1.8rem;
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.faq-item h4 {
+  font-size: 1.1rem;
+}
+
+.faq-item p {
+  color: var(--text-muted);
 }
 
 @media (max-width: 720px) {

--- a/public/testimonials.html
+++ b/public/testimonials.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Testimonials | Summit Property Management</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-page="testimonials">
+    <header class="hero page-hero">
+      <nav class="navbar">
+        <a class="logo" href="index.html">Summit<span>PM</span></a>
+        <ul class="nav-links">
+          <li><a href="index.html" data-page="home">Home</a></li>
+          <li><a href="services.html" data-page="services">Services</a></li>
+          <li><a href="portfolio.html" data-page="portfolio">Portfolio</a></li>
+          <li>
+            <a href="testimonials.html" data-page="testimonials">Testimonials</a>
+          </li>
+          <li><a href="contact.html" data-page="contact">Contact</a></li>
+        </ul>
+        <a href="contact.html" class="btn btn-outline">Request Proposal</a>
+      </nav>
+      <div class="hero-content">
+        <div class="hero-text">
+          <span class="eyebrow">Partner Perspectives</span>
+          <h1>What visionary owners and residents say about SummitPM</h1>
+          <p>
+            Long-term relationships are built on results, transparency, and the
+            human touch. Hear directly from the leaders who trust us with their
+            flagship assets.
+          </p>
+          <div class="hero-actions">
+            <a href="#voices" class="btn btn-primary">Read Testimonials</a>
+            <a href="contact.html" class="btn btn-ghost">Start a Conversation</a>
+          </div>
+        </div>
+        <div class="hero-stats">
+          <div class="stat-card">
+            <h3>4.9/5</h3>
+            <p>Average client satisfaction score across engagements</p>
+          </div>
+          <div class="stat-card">
+            <h3>12 yrs</h3>
+            <p>Longest active partnership with a single ownership group</p>
+          </div>
+          <div class="stat-card">
+            <h3>94%</h3>
+            <p>Residents who would recommend Summit-managed communities</p>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="section testimonials" id="voices">
+        <div class="section-header">
+          <span class="eyebrow">Voices</span>
+          <h2>Trusted by leaders in real estate, finance, and development</h2>
+          <p>
+            Our partners measure success in experiences, outcomes, and lasting
+            value. These are their words.
+          </p>
+        </div>
+        <div class="testimonial-grid">
+          <article class="testimonial-card">
+            <p>
+              “SummitPM is the rare operator that blends hospitality finesse with
+              rigorous financial discipline. Our residents rave about the
+              lifestyle programming, and our investors applaud the returns.”
+            </p>
+            <h4>Avery Chen</h4>
+            <span>Managing Director, Lattice Capital</span>
+          </article>
+          <article class="testimonial-card">
+            <p>
+              “Their transition plan was flawless. Within 30 days occupancy
+              rebounded, and the new maintenance standards have become a case
+              study for our entire portfolio.”
+            </p>
+            <h4>Jordan Ramirez</h4>
+            <span>Principal, Horizon Developments</span>
+          </article>
+          <article class="testimonial-card">
+            <p>
+              “The Summit team approaches every decision with the resident in
+              mind. Their concierge staff feels like an extension of our brand.”
+            </p>
+            <h4>Maya Patel</h4>
+            <span>Portfolio Director, Skylift Partners</span>
+          </article>
+          <article class="testimonial-card">
+            <p>
+              “Monthly reporting is timely, detailed, and actionable. We have
+              greater visibility into performance now than ever before.”
+            </p>
+            <h4>Isaac Moore</h4>
+            <span>Partner, Beacon Ridge Holdings</span>
+          </article>
+          <article class="testimonial-card">
+            <p>
+              “Their amenity activations have transformed our rooftop into the
+              neighborhood’s favorite gathering place.”
+            </p>
+            <h4>Sophia Alvarez</h4>
+            <span>Asset Manager, Meridian Ventures</span>
+          </article>
+          <article class="testimonial-card">
+            <p>
+              “I’ve never experienced a service team more responsive. SummitPM
+              anticipates needs before we have to ask.”
+            </p>
+            <h4>Lauren Kim</h4>
+            <span>Resident, Harborfront Lofts</span>
+          </article>
+        </div>
+      </section>
+
+      <section class="section section-dark">
+        <div class="section-split">
+          <div>
+            <span class="eyebrow">Service Philosophy</span>
+            <h2>Hospitality-first operations backed by measurable outcomes</h2>
+            <p>
+              Every touchpoint—concierge desk, maintenance ticket, resident
+              event—is designed to strengthen relationships and asset value.
+            </p>
+            <ul class="feature-list">
+              <li>Weekly resident sentiment analysis and action planning</li>
+              <li>Continuous training academies for on-site teams</li>
+              <li>Executive check-ins and strategic planning each quarter</li>
+            </ul>
+          </div>
+          <div class="pill-grid">
+            <div class="pill-card">
+              <h4>Resident Delight</h4>
+              <p>
+                Personalized welcome journeys, curated gifting, and effortless
+                service requests keep satisfaction soaring.
+              </p>
+            </div>
+            <div class="pill-card">
+              <h4>Owner Alignment</h4>
+              <p>
+                Transparent dashboards and leadership workshops ensure every goal
+                stays on track.
+              </p>
+            </div>
+            <div class="pill-card">
+              <h4>Team Empowerment</h4>
+              <p>
+                Coaching, recognition programs, and growth paths retain top-tier
+                hospitality talent.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <span class="eyebrow">Partners</span>
+          <h2>Global brands that collaborate with SummitPM</h2>
+          <p>
+            We activate experiences with cultural institutions, wellness leaders,
+            and culinary innovators to elevate every property.
+          </p>
+        </div>
+        <div class="logo-grid">
+          <div class="logo-card">Lumen Hospitality</div>
+          <div class="logo-card">Atlas Wellness Co.</div>
+          <div class="logo-card">Northbridge Finance</div>
+          <div class="logo-card">Urban Atelier Design</div>
+          <div class="logo-card">Skyline Culinary Group</div>
+          <div class="logo-card">Vertex Technologies</div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="footer-content">
+        <div>
+          <div class="logo">Summit<span>PM</span></div>
+          <p>
+            Boutique property management partners crafting elevated experiences
+            for residents, tenants, and owners.
+          </p>
+        </div>
+        <div class="footer-links">
+          <a href="services.html">Services</a>
+          <a href="portfolio.html">Portfolio</a>
+          <a href="testimonials.html">Testimonials</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <div class="footer-contact">
+          <p>hello@summitpm.com</p>
+          <p>+1 (312) 555-0198</p>
+          <p>123 Skyline Avenue, Suite 1800, Chicago, IL</p>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Summit Property Management. All rights reserved.</p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- convert the navbar to link to dedicated SummitPM pages and highlight the active section
- add services, portfolio, testimonials, and contact pages that reuse the existing aesthetic
- extend shared styles and scripts to support new layouts, cards, and grids while keeping consistent branding

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d45b0248cc83229c8e59ef040cd8e9