### PR TITLE
Connect contact form to Getaptly

### DIFF
--- a/public/contact.html
+++ b/public/contact.html
@@ -83,7 +83,12 @@
               </div>
             </div>
           </div>
-          <form class="contact-form">
+          <form
+            id="contactForm"
+            class="contact-form"
+            action="https://portal.getaptly.com/form/JxBQConmBLudiLuYH/new/cp4D2nkeASMiKu5P3"
+            method="POST"
+          >
             <div class="form-row">
               <input type="text" name="name" placeholder="Full Name" required />
               <input type="email" name="email" placeholder="Email Address" required />
@@ -98,6 +103,7 @@
               placeholder="Share the scope, timeline, and goals for your property"
             ></textarea>
             <button type="submit" class="btn btn-primary">Request Consultation</button>
+            <p id="contactMessage" class="form-message" role="status" aria-live="polite"></p>
           </form>
         </div>
       </section>

--- a/public/script.js
+++ b/public/script.js
@@ -24,4 +24,61 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
+
+  const contactForm = document.getElementById('contactForm');
+  if (contactForm) {
+    const messageEl = document.getElementById('contactMessage');
+    const submitButton = contactForm.querySelector('button[type="submit"]');
+
+    const setMessage = (type, text) => {
+      if (!messageEl) return;
+      messageEl.textContent = text;
+      messageEl.classList.remove('success', 'error');
+      if (type) {
+        messageEl.classList.add(type);
+      }
+    };
+
+    contactForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      setMessage('', '');
+
+      if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.dataset.originalText = submitButton.textContent;
+        submitButton.textContent = 'Sending...';
+      }
+
+      try {
+        const formData = new FormData(contactForm);
+        formData.append('source_url', window.location.href);
+
+        const response = await fetch(contactForm.action, {
+          method: contactForm.method || 'POST',
+          body: formData,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        contactForm.reset();
+        setMessage('success', 'Thank you! We’ll reach out shortly.');
+      } catch (error) {
+        console.error('Contact form submission failed:', error);
+        setMessage(
+          'error',
+          'We’re sorry—something went wrong. Please try again or email hello@summitpm.com.'
+        );
+      } finally {
+        if (submitButton) {
+          submitButton.disabled = false;
+          if (submitButton.dataset.originalText) {
+            submitButton.textContent = submitButton.dataset.originalText;
+            delete submitButton.dataset.originalText;
+          }
+        }
+      }
+    });
+  }
 });

--- a/public/styles.css
+++ b/public/styles.css
@@ -456,6 +456,20 @@ img {
   backdrop-filter: blur(10px);
 }
 
+.form-message {
+  min-height: 1.25rem;
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.form-message.success {
+  color: rgba(99, 236, 163, 0.92);
+}
+
+.form-message.error {
+  color: rgba(255, 173, 173, 0.9);
+}
+
 .form-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));


### PR DESCRIPTION
## Summary
- point the contact form at the provided Getaptly submission endpoint and add status messaging markup
- send submissions to Getaptly asynchronously and surface success or failure states to visitors
- add styling for inline form feedback to match the existing contact form design

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d45dd4e560832286001f81c7332d20