### PR TITLE
Add secure client portal experience

### DIFF
--- a/public/contact.html
+++ b/public/contact.html
@@ -25,6 +25,7 @@
             <a href="testimonials.html" data-page="testimonials">Testimonials</a>
           </li>
           <li><a href="contact.html" data-page="contact">Contact</a></li>
+          <li><a href="portal.html" data-page="portal">Portal</a></li>
         </ul>
         <a href="contact.html" class="btn btn-outline">Request Proposal</a>
       </nav>
@@ -204,6 +205,12 @@
           <p>hello@summitpm.com</p>
           <p>+1 (312) 555-0198</p>
           <p>123 Skyline Avenue, Suite 1800, Chicago, IL</p>
+        </div>
+        <div class="footer-portal">
+          <h4>Client portal</h4>
+          <p>Already onboarded? Manage assets and communications securely.</p>
+          <a href="portal.html" class="btn btn-primary footer-login">Access portal</a>
+          <span class="portal-support">Need help? Email support@summitpm.com</span>
         </div>
       </div>
       <p class="footer-bottom">© <span id="year"></span> Summit Property Management. All rights reserved.</p>

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
             <a href="testimonials.html" data-page="testimonials">Testimonials</a>
           </li>
           <li><a href="contact.html" data-page="contact">Contact</a></li>
+          <li><a href="portal.html" data-page="portal">Portal</a></li>
         </ul>
         <a href="contact.html" class="btn btn-outline">Request Proposal</a>
       </nav>
@@ -271,6 +272,12 @@
           <p>hello@summitpm.com</p>
           <p>+1 (312) 555-0198</p>
           <p>123 Skyline Avenue, Suite 1800, Chicago, IL</p>
+        </div>
+        <div class="footer-portal">
+          <h4>Client portal</h4>
+          <p>Already onboarded? Manage assets and communications securely.</p>
+          <a href="portal.html" class="btn btn-primary footer-login">Access portal</a>
+          <span class="portal-support">Need help? Email support@summitpm.com</span>
         </div>
       </div>
       <p class="footer-bottom">© <span id="year"></span> Summit Property Management. All rights reserved.</p>

--- a/public/portal.html
+++ b/public/portal.html
@@ -1,0 +1,361 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Client Portal | Summit Property Management</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-page="portal" class="portal-body">
+    <header class="hero portal-hero">
+      <nav class="navbar">
+        <a class="logo" href="index.html">Summit<span>PM</span></a>
+        <ul class="nav-links">
+          <li><a href="index.html" data-page="home">Home</a></li>
+          <li><a href="services.html" data-page="services">Services</a></li>
+          <li><a href="portfolio.html" data-page="portfolio">Portfolio</a></li>
+          <li>
+            <a href="testimonials.html" data-page="testimonials">Testimonials</a>
+          </li>
+          <li><a href="contact.html" data-page="contact">Contact</a></li>
+          <li><a href="portal.html" data-page="portal">Portal</a></li>
+        </ul>
+        <a href="contact.html" class="btn btn-outline">Request Proposal</a>
+      </nav>
+      <div class="hero-content portal-hero-content">
+        <div class="hero-text">
+          <span class="eyebrow">Secure Client &amp; Resident Access</span>
+          <h1>Manage your properties, documents, and site experience</h1>
+          <p>
+            Log in to review live portfolio performance, adjust communication
+            preferences, and publish the updates your residents see on the
+            public site.
+          </p>
+        </div>
+        <div class="portal-hero-card">
+          <h3>Portal benefits</h3>
+          <ul>
+            <li>Real-time occupancy &amp; revenue snapshots</li>
+            <li>Centralized maintenance tracking</li>
+            <li>Self-service branding &amp; notification controls</li>
+          </ul>
+        </div>
+      </div>
+    </header>
+
+    <main class="portal-main">
+      <section class="portal-auth" id="portal-auth">
+        <div class="portal-card">
+          <div class="portal-card-header">
+            <h2 id="auth-title">Welcome back</h2>
+            <p id="auth-subtitle">Log in to access your personalized dashboard.</p>
+          </div>
+          <form id="login-form" autocomplete="on">
+            <div class="form-group">
+              <label for="login-email">Email address</label>
+              <input type="email" id="login-email" name="email" required />
+            </div>
+            <div class="form-group">
+              <label for="login-password">Password</label>
+              <input
+                type="password"
+                id="login-password"
+                name="password"
+                minlength="8"
+                required
+              />
+            </div>
+            <div class="form-footer">
+              <label class="remember-toggle">
+                <input type="checkbox" id="remember-me" />
+                <span>Keep me signed in on this device</span>
+              </label>
+              <button type="button" class="link" data-switch="forgot">
+                Forgot password?
+              </button>
+            </div>
+            <p class="form-feedback" id="login-feedback"></p>
+            <button type="submit" class="btn btn-primary full-width">Log in</button>
+          </form>
+
+          <form id="signup-form" class="hidden" autocomplete="on">
+            <div class="form-group">
+              <label for="signup-name">Full name</label>
+              <input type="text" id="signup-name" name="name" required />
+            </div>
+            <div class="form-group">
+              <label for="signup-email">Work email</label>
+              <input type="email" id="signup-email" name="email" required />
+            </div>
+            <div class="form-group">
+              <label for="signup-password">Create password</label>
+              <input
+                type="password"
+                id="signup-password"
+                name="password"
+                minlength="8"
+                required
+              />
+            </div>
+            <div class="form-group">
+              <label for="signup-confirm">Confirm password</label>
+              <input
+                type="password"
+                id="signup-confirm"
+                name="confirm"
+                minlength="8"
+                required
+              />
+            </div>
+            <p class="form-feedback" id="signup-feedback"></p>
+            <button type="submit" class="btn btn-primary full-width">Create account</button>
+          </form>
+
+          <form id="forgot-form" class="hidden">
+            <div class="form-group">
+              <label for="forgot-email">Email address</label>
+              <input type="email" id="forgot-email" name="email" required />
+            </div>
+            <p class="form-feedback" id="forgot-feedback"></p>
+            <button type="submit" class="btn btn-primary full-width">Send reset link</button>
+          </form>
+
+          <div class="auth-toggle">
+            <p data-auth="login">
+              New to SummitPM?
+              <button type="button" class="link" data-switch="signup">Create an account</button>
+            </p>
+            <p data-auth="signup" class="hidden">
+              Already have an account?
+              <button type="button" class="link" data-switch="login">Log in</button>
+            </p>
+            <p data-auth="forgot" class="hidden">
+              Remembered your password?
+              <button type="button" class="link" data-switch="login">Return to login</button>
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="portal-app hidden" id="portal-app">
+        <aside class="portal-sidebar">
+          <div class="portal-user">
+            <span class="portal-user-role" id="portal-user-role"></span>
+            <h3 id="portal-user-name"></h3>
+            <p id="portal-user-email"></p>
+          </div>
+          <nav class="portal-menu">
+            <button class="portal-menu-link active" data-view="dashboard">Dashboard</button>
+            <button class="portal-menu-link" data-view="settings">Site settings</button>
+            <button class="portal-menu-link" data-view="profile">Profile &amp; security</button>
+          </nav>
+          <div class="portal-sidebar-footer">
+            <p class="last-login">Last login: <span id="last-login"></span></p>
+            <button class="btn btn-ghost full-width" id="logout-btn">Log out</button>
+          </div>
+        </aside>
+
+        <div class="portal-content">
+          <div class="portal-view" data-view="dashboard">
+            <div class="portal-view-header">
+              <h2 id="dashboard-title">Portfolio performance</h2>
+              <p id="dashboard-subtitle">A live snapshot of your assets and resident activity.</p>
+            </div>
+            <div class="portal-metrics">
+              <article class="metric-card">
+                <h3>Occupancy rate</h3>
+                <p class="metric-value" id="metric-occupancy">97%</p>
+                <span class="metric-trend" id="metric-occupancy-trend">+1.4% vs last month</span>
+              </article>
+              <article class="metric-card">
+                <h3>Net operating income</h3>
+                <p class="metric-value" id="metric-noi">$1.22M</p>
+                <span class="metric-trend" id="metric-noi-trend">+12% YoY</span>
+              </article>
+              <article class="metric-card">
+                <h3>Open maintenance tickets</h3>
+                <p class="metric-value" id="metric-tickets">3</p>
+                <span class="metric-trend" id="metric-tickets-trend">18 resolved this week</span>
+              </article>
+              <article class="metric-card">
+                <h3>Upcoming lease renewals</h3>
+                <p class="metric-value" id="metric-renewals">6</p>
+                <span class="metric-trend" id="metric-renewals-trend">Prepare retention offers</span>
+              </article>
+            </div>
+
+            <div class="portal-panels">
+              <section class="portal-panel">
+                <header>
+                  <h3>Resident communications</h3>
+                  <span id="resident-updates-count">4 updates queued</span>
+                </header>
+                <ul class="activity-feed" id="activity-feed"></ul>
+              </section>
+              <section class="portal-panel">
+                <header>
+                  <h3>Operational checklist</h3>
+                  <span>Prioritized tasks for your team</span>
+                </header>
+                <ul class="task-list" id="task-list"></ul>
+              </section>
+            </div>
+          </div>
+
+          <div class="portal-view hidden" data-view="settings">
+            <div class="portal-view-header">
+              <h2>Public site controls</h2>
+              <p>Update the messaging and automated communications residents see.</p>
+            </div>
+            <form id="site-settings-form" class="portal-form">
+              <div class="form-group">
+                <label for="setting-tagline">Homepage tagline</label>
+                <input type="text" id="setting-tagline" name="tagline" />
+                <span class="input-help">Displayed hero message for the marketing homepage.</span>
+              </div>
+              <div class="form-group">
+                <label for="setting-highlight">Featured property highlight</label>
+                <input type="text" id="setting-highlight" name="highlight" />
+                <span class="input-help">Displayed above the portfolio grid.</span>
+              </div>
+              <div class="form-group inline">
+                <label for="setting-maintenance">Maintenance mode</label>
+                <label class="switch">
+                  <input type="checkbox" id="setting-maintenance" name="maintenance" />
+                  <span class="slider"></span>
+                </label>
+                <span class="input-help">Temporarily hide booking forms while you update the site.</span>
+              </div>
+              <div class="form-group inline">
+                <label for="setting-auto-updates">Auto publish success stories</label>
+                <label class="switch">
+                  <input type="checkbox" id="setting-auto-updates" name="autoUpdates" />
+                  <span class="slider"></span>
+                </label>
+                <span class="input-help">Share testimonials automatically when approved.</span>
+              </div>
+              <p class="form-feedback" id="site-settings-feedback"></p>
+              <button type="submit" class="btn btn-primary">Save site preferences</button>
+            </form>
+
+            <form id="notification-settings-form" class="portal-form">
+              <div class="form-group inline">
+                <label for="notif-digest">Weekly performance digest</label>
+                <label class="switch">
+                  <input type="checkbox" id="notif-digest" name="digest" />
+                  <span class="slider"></span>
+                </label>
+                <span class="input-help">Email summary every Monday at 6 a.m. CST.</span>
+              </div>
+              <div class="form-group inline">
+                <label for="notif-critical">Critical incident SMS</label>
+                <label class="switch">
+                  <input type="checkbox" id="notif-critical" name="critical" />
+                  <span class="slider"></span>
+                </label>
+                <span class="input-help">Receive immediate texts for emergencies and escalations.</span>
+              </div>
+              <div class="form-group inline">
+                <label for="notif-townhall">Resident town hall invites</label>
+                <label class="switch">
+                  <input type="checkbox" id="notif-townhall" name="townhall" />
+                  <span class="slider"></span>
+                </label>
+                <span class="input-help">Automatically send upcoming event invitations.</span>
+              </div>
+              <p class="form-feedback" id="notification-feedback"></p>
+              <button type="submit" class="btn btn-primary">Update notifications</button>
+            </form>
+          </div>
+
+          <div class="portal-view hidden" data-view="profile">
+            <div class="portal-view-header">
+              <h2>Profile &amp; security</h2>
+              <p>Keep your contact details current and protect account access.</p>
+            </div>
+            <form id="profile-form" class="portal-form">
+              <div class="form-group">
+                <label for="profile-name">Full name</label>
+                <input type="text" id="profile-name" name="name" required />
+              </div>
+              <div class="form-group">
+                <label for="profile-phone">Mobile phone</label>
+                <input type="tel" id="profile-phone" name="phone" placeholder="(312) 555-0198" />
+              </div>
+              <div class="form-group">
+                <label for="profile-title">Role or title</label>
+                <input type="text" id="profile-title" name="title" />
+              </div>
+              <p class="form-feedback" id="profile-feedback"></p>
+              <button type="submit" class="btn btn-primary">Save profile</button>
+            </form>
+
+            <form id="password-form" class="portal-form">
+              <div class="form-group">
+                <label for="password-current">Current password</label>
+                <input type="password" id="password-current" name="current" required minlength="8" />
+              </div>
+              <div class="form-group">
+                <label for="password-new">New password</label>
+                <input type="password" id="password-new" name="next" required minlength="8" />
+              </div>
+              <div class="form-group">
+                <label for="password-confirm">Confirm new password</label>
+                <input type="password" id="password-confirm" name="confirm" required minlength="8" />
+              </div>
+              <p class="form-feedback" id="password-feedback"></p>
+              <button type="submit" class="btn btn-primary">Update password</button>
+            </form>
+
+            <section class="portal-panel security-panel">
+              <header>
+                <h3>Login activity</h3>
+                <span>Most recent sign-ins from recognized devices</span>
+              </header>
+              <ul class="activity-feed" id="security-log"></ul>
+            </section>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="footer-content">
+        <div>
+          <div class="logo">Summit<span>PM</span></div>
+          <p>
+            Boutique property management partners crafting elevated experiences
+            for residents, tenants, and owners.
+          </p>
+        </div>
+        <div class="footer-links">
+          <a href="services.html">Services</a>
+          <a href="portfolio.html">Portfolio</a>
+          <a href="testimonials.html">Testimonials</a>
+          <a href="contact.html">Contact</a>
+        </div>
+        <div class="footer-contact">
+          <p>hello@summitpm.com</p>
+          <p>+1 (312) 555-0198</p>
+          <p>123 Skyline Avenue, Suite 1800, Chicago, IL</p>
+        </div>
+        <div class="footer-portal">
+          <h4>Client portal</h4>
+          <p>Already onboarded? Manage assets and communications securely.</p>
+          <a href="portal.html" class="btn btn-primary footer-login">Access portal</a>
+          <span class="portal-support">Need help? Email support@summitpm.com</span>
+        </div>
+      </div>
+      <p class="footer-bottom">© <span id="year"></span> Summit Property Management. All rights reserved.</p>
+    </footer>
+
+    <script src="script.js"></script>
+    <script src="portal.js"></script>
+  </body>
+</html>

--- a/public/portal.js
+++ b/public/portal.js
@@ -1,0 +1,711 @@
+const PortalApp = (() => {
+  const USER_KEY = 'summitPortalUsers';
+  const SESSION_KEY = 'summitPortalSession';
+  const SETTINGS_KEY = 'summitPortalSiteSettings';
+
+  const defaultSiteSettings = {
+    tagline: 'Elevated property performance engineered for people.',
+    highlight: 'Now leasing: Harborfront Lofts — 98% occupancy milestone',
+    maintenance: false,
+    autoUpdates: true,
+  };
+
+  const defaultUsersSeed = [
+    {
+      id: 'user-1001',
+      name: 'Avery Chen',
+      email: 'owner@summitpm.com',
+      role: 'Portfolio Owner',
+      title: 'Managing Director, Lattice Capital',
+      phone: '(312) 555-0198',
+      status: 'Active',
+      passwordHash: null,
+      lastLogin: '2024-09-12T14:05:00.000Z',
+      previousLogin: '2024-09-05T08:12:00.000Z',
+      preferences: {
+        digest: true,
+        critical: true,
+        townhall: true,
+      },
+      dashboard: {
+        occupancy: 0.97,
+        occupancyTrend: 1.4,
+        noi: 1220000,
+        noiTrend: 12,
+        tickets: 3,
+        ticketsResolved: 18,
+        renewals: 6,
+      },
+      securityLog: [
+        {
+          device: 'Chrome on macOS',
+          location: 'Chicago, IL',
+          time: '2024-09-12T14:05:00.000Z',
+        },
+        {
+          device: 'SummitPM Mobile',
+          location: 'Chicago, IL',
+          time: '2024-09-05T08:12:00.000Z',
+        },
+      ],
+    },
+  ];
+
+  const mockResidentUpdates = [
+    {
+      title: 'Concierge wellness series announced',
+      detail: 'Three-part rooftop wellness program scheduled for October residents.',
+      time: '2024-09-11T15:24:00.000Z',
+    },
+    {
+      title: 'Sustainability dashboard live',
+      detail: 'Energy consumption report ready for board review before quarterly meeting.',
+      time: '2024-09-10T11:00:00.000Z',
+    },
+    {
+      title: 'Amenity booking surge',
+      detail: 'Infinity pool reservations now at 86% capacity for the weekend.',
+      time: '2024-09-09T08:45:00.000Z',
+    },
+    {
+      title: 'Harborfront Lofts feedback',
+      detail: 'Post-renovation satisfaction survey response rate crossed 92%.',
+      time: '2024-09-08T19:10:00.000Z',
+    },
+  ];
+
+  const mockTasks = [
+    {
+      title: 'Approve fall resident engagement campaign',
+      due: '2024-09-15',
+      priority: 'High',
+    },
+    {
+      title: 'Upload August financial statements',
+      due: '2024-09-13',
+      priority: 'Medium',
+    },
+    {
+      title: 'Review concierge staffing coverage',
+      due: '2024-09-18',
+      priority: 'Medium',
+    },
+    {
+      title: 'Sign off on vendor sustainability proposal',
+      due: '2024-09-20',
+      priority: 'Low',
+    },
+  ];
+
+  const state = {
+    users: [],
+    currentUser: null,
+    siteSettings: null,
+  };
+
+  const elements = {};
+
+  const authCopy = {
+    login: {
+      title: 'Welcome back',
+      subtitle: 'Log in to access your personalized dashboard.',
+    },
+    signup: {
+      title: 'Create your secure portal access',
+      subtitle:
+        'Set up a login to track performance and control the public-facing experience.',
+    },
+    forgot: {
+      title: 'Reset your password',
+      subtitle: 'Enter the email associated with your account to receive a reset link.',
+    },
+  };
+
+  const clone = (value) => JSON.parse(JSON.stringify(value));
+
+  const bufferToHex = (buffer) => {
+    const bytes = new Uint8Array(buffer);
+    return Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  };
+
+  const hashPassword = async (password) => {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(password);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+    return bufferToHex(hashBuffer);
+  };
+
+  const ensureDefaultUsers = async () => {
+    const stored = localStorage.getItem(USER_KEY);
+    if (!stored) {
+      const seededUsers = clone(defaultUsersSeed);
+      seededUsers[0].passwordHash = await hashPassword('Summit@123');
+      localStorage.setItem(USER_KEY, JSON.stringify(seededUsers));
+    }
+  };
+
+  const loadUsers = () => {
+    try {
+      const stored = localStorage.getItem(USER_KEY);
+      if (!stored) {
+        state.users = clone(defaultUsersSeed);
+        return;
+      }
+      state.users = JSON.parse(stored);
+    } catch (error) {
+      console.error('Failed to parse stored portal users', error);
+      state.users = clone(defaultUsersSeed);
+    }
+  };
+
+  const saveUsers = () => {
+    localStorage.setItem(USER_KEY, JSON.stringify(state.users));
+  };
+
+  const loadSiteSettings = () => {
+    try {
+      const stored = localStorage.getItem(SETTINGS_KEY);
+      if (!stored) {
+        state.siteSettings = clone(defaultSiteSettings);
+        return;
+      }
+      state.siteSettings = { ...clone(defaultSiteSettings), ...JSON.parse(stored) };
+    } catch (error) {
+      console.error('Failed to parse stored site settings', error);
+      state.siteSettings = clone(defaultSiteSettings);
+    }
+  };
+
+  const saveSiteSettings = () => {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(state.siteSettings));
+  };
+
+  const getSessionUserId = () =>
+    localStorage.getItem(SESSION_KEY) || sessionStorage.getItem(SESSION_KEY);
+
+  const persistSession = (userId, remember) => {
+    if (remember) {
+      localStorage.setItem(SESSION_KEY, userId);
+      sessionStorage.removeItem(SESSION_KEY);
+    } else {
+      sessionStorage.setItem(SESSION_KEY, userId);
+      localStorage.removeItem(SESSION_KEY);
+    }
+  };
+
+  const clearSession = () => {
+    localStorage.removeItem(SESSION_KEY);
+    sessionStorage.removeItem(SESSION_KEY);
+  };
+
+  const findUserByEmail = (email) =>
+    state.users.find((user) => user.email.toLowerCase() === email.toLowerCase());
+
+  const formatCurrency = (value) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+
+  const formatPercent = (value) => `${(value * 100).toFixed(0)}%`;
+
+  const formatTrend = (value) =>
+    `${value >= 0 ? '+' : ''}${value.toFixed(1)}% vs last period`;
+
+  const formatRelative = (isoString) => {
+    if (!isoString) return '—';
+    const now = new Date();
+    const date = new Date(isoString);
+    const diffMs = now.getTime() - date.getTime();
+    const diffMinutes = Math.floor(diffMs / 60000);
+    if (diffMinutes < 1) return 'Just now';
+    if (diffMinutes < 60) return `${diffMinutes} min ago`;
+    const diffHours = Math.floor(diffMinutes / 60);
+    if (diffHours < 24) return `${diffHours} hr ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+    return date.toLocaleDateString();
+  };
+
+  const formatDate = (isoString) => {
+    if (!isoString) return 'First access';
+    return new Date(isoString).toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  };
+
+  const getDeviceFingerprint = () => {
+    const ua = navigator.userAgent;
+    if (/mobile/i.test(ua)) {
+      return 'SummitPM Mobile';
+    }
+    if (/Macintosh/i.test(ua)) {
+      return 'Browser on macOS';
+    }
+    if (/Windows/i.test(ua)) {
+      return 'Browser on Windows';
+    }
+    return 'Secure browser session';
+  };
+
+  const renderDashboard = (user) => {
+    const { dashboard } = user;
+    if (!dashboard) return;
+    elements.metricOccupancy.textContent = formatPercent(dashboard.occupancy);
+    elements.metricOccupancyTrend.textContent = formatTrend(dashboard.occupancyTrend);
+    elements.metricNoi.textContent = formatCurrency(dashboard.noi);
+    elements.metricNoiTrend.textContent = `+${dashboard.noiTrend}% YoY`;
+    elements.metricTickets.textContent = dashboard.tickets;
+    elements.metricTicketsTrend.textContent = `${dashboard.ticketsResolved} resolved this week`;
+    elements.metricRenewals.textContent = dashboard.renewals;
+    elements.metricRenewalsTrend.textContent = 'Prepare retention offers';
+
+    elements.residentUpdatesCount.textContent = `${mockResidentUpdates.length} updates queued`;
+    elements.activityFeed.innerHTML = '';
+    mockResidentUpdates.forEach((item) => {
+      const li = document.createElement('li');
+      li.innerHTML = `
+        <div class="feed-title">${item.title}</div>
+        <p>${item.detail}</p>
+        <span class="feed-time">${formatRelative(item.time)}</span>
+      `;
+      elements.activityFeed.appendChild(li);
+    });
+
+    elements.taskList.innerHTML = '';
+    mockTasks.forEach((task) => {
+      const li = document.createElement('li');
+      li.innerHTML = `
+        <div>
+          <strong>${task.title}</strong>
+          <p>Due ${new Date(task.due).toLocaleDateString()}</p>
+        </div>
+        <span class="task-priority task-${task.priority.toLowerCase()}">${task.priority}</span>
+      `;
+      elements.taskList.appendChild(li);
+    });
+  };
+
+  const populateSettingsForms = (user) => {
+    const settings = state.siteSettings || defaultSiteSettings;
+    elements.settingTagline.value = settings.tagline;
+    elements.settingHighlight.value = settings.highlight;
+    elements.settingMaintenance.checked = Boolean(settings.maintenance);
+    elements.settingAutoUpdates.checked = Boolean(settings.autoUpdates);
+
+    const prefs = user.preferences || {};
+    elements.notifDigest.checked = Boolean(prefs.digest);
+    elements.notifCritical.checked = Boolean(prefs.critical);
+    elements.notifTownhall.checked = Boolean(prefs.townhall);
+  };
+
+  const populateProfileForm = (user) => {
+    elements.profileName.value = user.name || '';
+    elements.portalUserName.textContent = user.name || 'SummitPM Client';
+    elements.portalUserRole.textContent = user.role || 'Client';
+    elements.portalUserEmail.textContent = user.email;
+    elements.profilePhone.value = user.phone || '';
+    elements.profileTitle.value = user.title || '';
+    elements.lastLogin.textContent = formatDate(user.previousLogin) || 'First access';
+  };
+
+  const renderSecurityLog = (user) => {
+    elements.securityLog.innerHTML = '';
+    (user.securityLog || []).slice(0, 5).forEach((entry) => {
+      const li = document.createElement('li');
+      li.innerHTML = `
+        <div class="feed-title">${entry.device}</div>
+        <p>${entry.location || 'Verified device'}</p>
+        <span class="feed-time">${formatDate(entry.time)}</span>
+      `;
+      elements.securityLog.appendChild(li);
+    });
+  };
+
+  const showFeedback = (el, message, type = 'info') => {
+    if (!el) return;
+    el.textContent = message;
+    el.dataset.state = type;
+    if (message) {
+      setTimeout(() => {
+        if (el.textContent === message) {
+          el.textContent = '';
+          el.dataset.state = '';
+        }
+      }, 6000);
+    }
+  };
+
+  const switchAuthView = (view) => {
+    elements.loginForm.classList.toggle('hidden', view !== 'login');
+    elements.signupForm.classList.toggle('hidden', view !== 'signup');
+    elements.forgotForm.classList.toggle('hidden', view !== 'forgot');
+
+    document
+      .querySelectorAll('.auth-toggle [data-auth]')
+      .forEach((toggle) => toggle.classList.toggle('hidden', toggle.dataset.auth !== view));
+
+    elements.authTitle.textContent = authCopy[view].title;
+    elements.authSubtitle.textContent = authCopy[view].subtitle;
+  };
+
+  const enterPortal = (user, options = {}) => {
+    state.currentUser = user;
+    document.body.classList.add('portal-authenticated');
+    elements.portalAuth.classList.add('hidden');
+    elements.portalApp.classList.remove('hidden');
+    populateSettingsForms(user);
+    populateProfileForm(user);
+    renderDashboard(user);
+    renderSecurityLog(user);
+    if (!options.skipScroll) {
+      window.scrollTo({ top: elements.portalApp.offsetTop - 80, behavior: 'smooth' });
+    }
+  };
+
+  const logout = () => {
+    clearSession();
+    state.currentUser = null;
+    document.body.classList.remove('portal-authenticated');
+    elements.portalAuth.classList.remove('hidden');
+    elements.portalApp.classList.add('hidden');
+    switchAuthView('login');
+  };
+
+  const handleLogin = async (event) => {
+    event.preventDefault();
+    showFeedback(elements.loginFeedback, '');
+    const email = elements.loginEmail.value.trim();
+    const password = elements.loginPassword.value;
+    const remember = elements.rememberMe.checked;
+
+    const user = findUserByEmail(email);
+    if (!user) {
+      showFeedback(elements.loginFeedback, 'We could not find an account with that email.', 'error');
+      return;
+    }
+
+    const hashed = await hashPassword(password);
+    if (user.passwordHash !== hashed) {
+      showFeedback(
+        elements.loginFeedback,
+        'Incorrect password. Please try again or reset your password.',
+        'error',
+      );
+      return;
+    }
+
+    const nowIso = new Date().toISOString();
+    user.previousLogin = user.lastLogin || nowIso;
+    user.lastLogin = nowIso;
+    const fingerprint = getDeviceFingerprint();
+    user.securityLog = [
+      {
+        device: fingerprint,
+        location: 'Secure session',
+        time: nowIso,
+      },
+      ...(user.securityLog || []).slice(0, 4),
+    ];
+    saveUsers();
+    persistSession(user.id, remember);
+    enterPortal(user);
+  };
+
+  const generateDashboardSeed = () => ({
+    occupancy: 0.94 + Math.random() * 0.05,
+    occupancyTrend: 0.4 + Math.random() * 1.2,
+    noi: 950000 + Math.floor(Math.random() * 400000),
+    noiTrend: 8 + Math.floor(Math.random() * 6),
+    tickets: Math.floor(Math.random() * 4) + 2,
+    ticketsResolved: Math.floor(Math.random() * 15) + 8,
+    renewals: Math.floor(Math.random() * 8) + 3,
+  });
+
+  const handleSignup = async (event) => {
+    event.preventDefault();
+    showFeedback(elements.signupFeedback, '');
+    const name = elements.signupName.value.trim();
+    const email = elements.signupEmail.value.trim();
+    const password = elements.signupPassword.value;
+    const confirm = elements.signupConfirm.value;
+
+    if (!/^[\w-.]+@([\w-]+\.)+[\w-]{2,}$/i.test(email)) {
+      showFeedback(elements.signupFeedback, 'Please provide a valid work email address.', 'error');
+      return;
+    }
+
+    if (password !== confirm) {
+      showFeedback(elements.signupFeedback, 'Passwords do not match. Please try again.', 'error');
+      return;
+    }
+
+    if (password.length < 8 || !/[A-Z]/.test(password) || !/[0-9]/.test(password)) {
+      showFeedback(
+        elements.signupFeedback,
+        'Use a stronger password with at least 8 characters, one capital letter, and one number.',
+        'error',
+      );
+      return;
+    }
+
+    if (findUserByEmail(email)) {
+      showFeedback(elements.signupFeedback, 'An account already exists for this email.', 'error');
+      return;
+    }
+
+    const hashed = await hashPassword(password);
+    const newUser = {
+      id: `user-${Date.now()}`,
+      name,
+      email,
+      role: 'Portfolio Owner',
+      title: '',
+      phone: '',
+      status: 'Active',
+      passwordHash: hashed,
+      lastLogin: new Date().toISOString(),
+      previousLogin: null,
+      preferences: {
+        digest: true,
+        critical: true,
+        townhall: false,
+      },
+      dashboard: generateDashboardSeed(),
+      securityLog: [],
+    };
+
+    state.users.push(newUser);
+    saveUsers();
+    persistSession(newUser.id, true);
+    enterPortal(newUser, { skipScroll: false });
+    showFeedback(elements.signupFeedback, 'Account created. You are now signed in.', 'success');
+  };
+
+  const handleForgotPassword = (event) => {
+    event.preventDefault();
+    showFeedback(elements.forgotFeedback, '');
+    const email = elements.forgotEmail.value.trim();
+    if (!email) {
+      showFeedback(elements.forgotFeedback, 'Please provide the email associated with your account.', 'error');
+      return;
+    }
+
+    const user = findUserByEmail(email);
+    if (!user) {
+      showFeedback(
+        elements.forgotFeedback,
+        'If that email is registered, a reset link will arrive within a few minutes.',
+        'info',
+      );
+      return;
+    }
+
+    showFeedback(
+      elements.forgotFeedback,
+      `A secure reset link has been sent to ${email}. Check your inbox for next steps.`,
+      'success',
+    );
+  };
+
+  const handleSiteSettings = (event) => {
+    event.preventDefault();
+    state.siteSettings = {
+      ...state.siteSettings,
+      tagline: elements.settingTagline.value.trim(),
+      highlight: elements.settingHighlight.value.trim(),
+      maintenance: elements.settingMaintenance.checked,
+      autoUpdates: elements.settingAutoUpdates.checked,
+    };
+    saveSiteSettings();
+    showFeedback(elements.siteSettingsFeedback, 'Site preferences updated successfully.', 'success');
+  };
+
+  const handleNotificationSettings = (event) => {
+    event.preventDefault();
+    if (!state.currentUser) return;
+    state.currentUser.preferences = {
+      digest: elements.notifDigest.checked,
+      critical: elements.notifCritical.checked,
+      townhall: elements.notifTownhall.checked,
+    };
+    saveUsers();
+    showFeedback(elements.notificationFeedback, 'Notification preferences saved.', 'success');
+  };
+
+  const handleProfileUpdate = (event) => {
+    event.preventDefault();
+    if (!state.currentUser) return;
+    state.currentUser.name = elements.profileName.value.trim();
+    state.currentUser.phone = elements.profilePhone.value.trim();
+    state.currentUser.title = elements.profileTitle.value.trim();
+    saveUsers();
+    populateProfileForm(state.currentUser);
+    showFeedback(elements.profileFeedback, 'Profile updated successfully.', 'success');
+  };
+
+  const handlePasswordUpdate = async (event) => {
+    event.preventDefault();
+    if (!state.currentUser) return;
+    const current = elements.passwordCurrent.value;
+    const next = elements.passwordNew.value;
+    const confirm = elements.passwordConfirm.value;
+    showFeedback(elements.passwordFeedback, '');
+
+    const hashedCurrent = await hashPassword(current);
+    if (hashedCurrent !== state.currentUser.passwordHash) {
+      showFeedback(elements.passwordFeedback, 'Current password is incorrect.', 'error');
+      return;
+    }
+
+    if (next !== confirm) {
+      showFeedback(elements.passwordFeedback, 'New passwords do not match.', 'error');
+      return;
+    }
+
+    if (next.length < 8 || !/[A-Z]/.test(next) || !/[0-9]/.test(next) || !/[^A-Za-z0-9]/.test(next)) {
+      showFeedback(
+        elements.passwordFeedback,
+        'Use at least 8 characters with a number, capital letter, and symbol.',
+        'error',
+      );
+      return;
+    }
+
+    state.currentUser.passwordHash = await hashPassword(next);
+    const nowIso = new Date().toISOString();
+    state.currentUser.securityLog = [
+      {
+        device: 'Credential update',
+        location: 'Secure session',
+        time: nowIso,
+      },
+      ...(state.currentUser.securityLog || []).slice(0, 4),
+    ];
+    saveUsers();
+    renderSecurityLog(state.currentUser);
+    showFeedback(elements.passwordFeedback, 'Password updated successfully.', 'success');
+    event.target.reset();
+  };
+
+  const bindMenu = () => {
+    document.querySelectorAll('.portal-menu-link').forEach((button) => {
+      button.addEventListener('click', () => {
+        const target = button.dataset.view;
+        document
+          .querySelectorAll('.portal-menu-link')
+          .forEach((item) => item.classList.toggle('active', item === button));
+        document
+          .querySelectorAll('.portal-view')
+          .forEach((view) => view.classList.toggle('hidden', view.dataset.view !== target));
+      });
+    });
+  };
+
+  const bindAuthSwitches = () => {
+    document.querySelectorAll('[data-switch]').forEach((button) => {
+      button.addEventListener('click', () => {
+        switchAuthView(button.dataset.switch);
+      });
+    });
+  };
+
+  const bindEvents = () => {
+    elements.loginForm.addEventListener('submit', handleLogin);
+    elements.signupForm.addEventListener('submit', handleSignup);
+    elements.forgotForm.addEventListener('submit', handleForgotPassword);
+    elements.siteSettingsForm.addEventListener('submit', handleSiteSettings);
+    elements.notificationSettingsForm.addEventListener('submit', handleNotificationSettings);
+    elements.profileForm.addEventListener('submit', handleProfileUpdate);
+    elements.passwordForm.addEventListener('submit', handlePasswordUpdate);
+    elements.logoutBtn.addEventListener('click', logout);
+    bindMenu();
+    bindAuthSwitches();
+  };
+
+  const cacheElements = () => {
+    elements.portalAuth = document.getElementById('portal-auth');
+    elements.portalApp = document.getElementById('portal-app');
+    elements.authTitle = document.getElementById('auth-title');
+    elements.authSubtitle = document.getElementById('auth-subtitle');
+    elements.loginForm = document.getElementById('login-form');
+    elements.signupForm = document.getElementById('signup-form');
+    elements.forgotForm = document.getElementById('forgot-form');
+    elements.loginEmail = document.getElementById('login-email');
+    elements.loginPassword = document.getElementById('login-password');
+    elements.rememberMe = document.getElementById('remember-me');
+    elements.loginFeedback = document.getElementById('login-feedback');
+    elements.signupName = document.getElementById('signup-name');
+    elements.signupEmail = document.getElementById('signup-email');
+    elements.signupPassword = document.getElementById('signup-password');
+    elements.signupConfirm = document.getElementById('signup-confirm');
+    elements.signupFeedback = document.getElementById('signup-feedback');
+    elements.forgotEmail = document.getElementById('forgot-email');
+    elements.forgotFeedback = document.getElementById('forgot-feedback');
+    elements.metricOccupancy = document.getElementById('metric-occupancy');
+    elements.metricOccupancyTrend = document.getElementById('metric-occupancy-trend');
+    elements.metricNoi = document.getElementById('metric-noi');
+    elements.metricNoiTrend = document.getElementById('metric-noi-trend');
+    elements.metricTickets = document.getElementById('metric-tickets');
+    elements.metricTicketsTrend = document.getElementById('metric-tickets-trend');
+    elements.metricRenewals = document.getElementById('metric-renewals');
+    elements.metricRenewalsTrend = document.getElementById('metric-renewals-trend');
+    elements.residentUpdatesCount = document.getElementById('resident-updates-count');
+    elements.activityFeed = document.getElementById('activity-feed');
+    elements.taskList = document.getElementById('task-list');
+    elements.settingTagline = document.getElementById('setting-tagline');
+    elements.settingHighlight = document.getElementById('setting-highlight');
+    elements.settingMaintenance = document.getElementById('setting-maintenance');
+    elements.settingAutoUpdates = document.getElementById('setting-auto-updates');
+    elements.siteSettingsForm = document.getElementById('site-settings-form');
+    elements.siteSettingsFeedback = document.getElementById('site-settings-feedback');
+    elements.notificationSettingsForm = document.getElementById('notification-settings-form');
+    elements.notificationFeedback = document.getElementById('notification-feedback');
+    elements.notifDigest = document.getElementById('notif-digest');
+    elements.notifCritical = document.getElementById('notif-critical');
+    elements.notifTownhall = document.getElementById('notif-townhall');
+    elements.portalUserName = document.getElementById('portal-user-name');
+    elements.portalUserRole = document.getElementById('portal-user-role');
+    elements.portalUserEmail = document.getElementById('portal-user-email');
+    elements.lastLogin = document.getElementById('last-login');
+    elements.profileForm = document.getElementById('profile-form');
+    elements.profileName = document.getElementById('profile-name');
+    elements.profilePhone = document.getElementById('profile-phone');
+    elements.profileTitle = document.getElementById('profile-title');
+    elements.profileFeedback = document.getElementById('profile-feedback');
+    elements.passwordForm = document.getElementById('password-form');
+    elements.passwordCurrent = document.getElementById('password-current');
+    elements.passwordNew = document.getElementById('password-new');
+    elements.passwordConfirm = document.getElementById('password-confirm');
+    elements.passwordFeedback = document.getElementById('password-feedback');
+    elements.securityLog = document.getElementById('security-log');
+    elements.logoutBtn = document.getElementById('logout-btn');
+  };
+
+  const restoreSessionIfPresent = () => {
+    const sessionId = getSessionUserId();
+    if (!sessionId) return;
+    const user = state.users.find((item) => item.id === sessionId);
+    if (user) {
+      enterPortal(user, { skipScroll: true });
+    }
+  };
+
+  const init = async () => {
+    await ensureDefaultUsers();
+    loadUsers();
+    loadSiteSettings();
+    cacheElements();
+    bindEvents();
+    restoreSessionIfPresent();
+  };
+
+  return { init };
+})();
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (document.body.dataset.page !== 'portal') return;
+  PortalApp.init();
+});

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -24,6 +24,7 @@
             <a href="testimonials.html" data-page="testimonials">Testimonials</a>
           </li>
           <li><a href="contact.html" data-page="contact">Contact</a></li>
+          <li><a href="portal.html" data-page="portal">Portal</a></li>
         </ul>
         <a href="contact.html" class="btn btn-outline">Request Proposal</a>
       </nav>
@@ -234,6 +235,12 @@
           <p>hello@summitpm.com</p>
           <p>+1 (312) 555-0198</p>
           <p>123 Skyline Avenue, Suite 1800, Chicago, IL</p>
+        </div>
+        <div class="footer-portal">
+          <h4>Client portal</h4>
+          <p>Already onboarded? Manage assets and communications securely.</p>
+          <a href="portal.html" class="btn btn-primary footer-login">Access portal</a>
+          <span class="portal-support">Need help? Email support@summitpm.com</span>
         </div>
       </div>
       <p class="footer-bottom">© <span id="year"></span> Summit Property Management. All rights reserved.</p>

--- a/public/services.html
+++ b/public/services.html
@@ -24,6 +24,7 @@
             <a href="testimonials.html" data-page="testimonials">Testimonials</a>
           </li>
           <li><a href="contact.html" data-page="contact">Contact</a></li>
+          <li><a href="portal.html" data-page="portal">Portal</a></li>
         </ul>
         <a href="contact.html" class="btn btn-outline">Request Proposal</a>
       </nav>
@@ -229,6 +230,12 @@
           <p>hello@summitpm.com</p>
           <p>+1 (312) 555-0198</p>
           <p>123 Skyline Avenue, Suite 1800, Chicago, IL</p>
+        </div>
+        <div class="footer-portal">
+          <h4>Client portal</h4>
+          <p>Already onboarded? Manage assets and communications securely.</p>
+          <a href="portal.html" class="btn btn-primary footer-login">Access portal</a>
+          <span class="portal-support">Need help? Email support@summitpm.com</span>
         </div>
       </div>
       <p class="footer-bottom">© <span id="year"></span> Summit Property Management. All rights reserved.</p>

--- a/public/styles.css
+++ b/public/styles.css
@@ -527,6 +527,25 @@ textarea:focus {
   color: rgba(255, 255, 255, 0.45);
 }
 
+.footer-portal {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.footer-portal h4 {
+  font-size: 1.05rem;
+  color: #fff;
+}
+
+.footer-login {
+  justify-self: start;
+}
+
+.portal-support {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
 .section-dark {
   background: #0b1322;
   color: #fff;
@@ -718,5 +737,483 @@ textarea:focus {
 
   .hero-stats {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}
+
+/* Portal Experience */
+.hidden {
+  display: none !important;
+}
+
+.link {
+  background: none;
+  border: none;
+  color: var(--primary);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.portal-body {
+  background: var(--bg-light);
+}
+
+.portal-hero {
+  background: linear-gradient(rgba(6, 11, 22, 0.78), rgba(6, 11, 22, 0.85)),
+    url('https://images.unsplash.com/photo-1529429617124-aee0a9429e5a?auto=format&fit=crop&w=1600&q=80')
+      center/cover no-repeat;
+}
+
+.portal-hero-content {
+  align-items: start;
+}
+
+.portal-hero-card {
+  background: rgba(255, 255, 255, 0.12);
+  padding: 1.75rem;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(8px);
+  align-self: center;
+}
+
+.portal-hero-card h3 {
+  margin-bottom: 1rem;
+  color: #fff;
+}
+
+.portal-hero-card ul {
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.portal-main {
+  margin-top: -4rem;
+  padding: 0 clamp(1.5rem, 5vw, 4rem) 5rem;
+  position: relative;
+  z-index: 2;
+}
+
+.portal-auth {
+  max-width: 420px;
+  margin: 0 auto;
+  transform: translateY(-50%);
+}
+
+.portal-card {
+  background: #fff;
+  border-radius: 24px;
+  padding: clamp(2rem, 4vw, 2.5rem);
+  box-shadow: 0 30px 60px rgba(6, 11, 22, 0.15);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.portal-card-header {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.portal-card-header h2 {
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  color: var(--text-main);
+}
+
+.portal-card-header p {
+  color: var(--text-muted);
+}
+
+.portal-card input,
+.portal-card textarea,
+.portal-form input,
+.portal-form textarea,
+.portal-form select {
+  background: rgba(10, 27, 42, 0.06);
+  border: 1px solid rgba(10, 27, 42, 0.12);
+  color: var(--text-main);
+}
+
+.portal-card input::placeholder,
+.portal-form input::placeholder,
+.portal-form textarea::placeholder {
+  color: rgba(10, 27, 42, 0.45);
+}
+
+.portal-card input:focus,
+.portal-form input:focus,
+.portal-form textarea:focus {
+  outline: 2px solid rgba(122, 201, 255, 0.65);
+  background: #fff;
+}
+
+.form-group {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.form-group.inline {
+  grid-template-columns: auto 60px;
+  align-items: center;
+  gap: 1rem;
+}
+
+.form-group.inline .switch {
+  justify-self: end;
+}
+
+.form-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.remember-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.remember-toggle input {
+  accent-color: var(--primary);
+}
+
+.form-feedback {
+  min-height: 1.25rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.form-feedback[data-state='error'] {
+  color: #d33f49;
+}
+
+.form-feedback[data-state='success'] {
+  color: #1f9254;
+}
+
+.auth-toggle {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.portal-app {
+  display: grid;
+  grid-template-columns: minmax(240px, 280px) 1fr;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  margin-top: clamp(2rem, 5vw, 4rem);
+}
+
+.portal-sidebar {
+  background: #071020;
+  border-radius: 24px;
+  padding: 2rem 1.5rem;
+  color: rgba(255, 255, 255, 0.78);
+  display: grid;
+  gap: 2.5rem;
+  box-shadow: 0 24px 50px rgba(5, 18, 32, 0.4);
+}
+
+.portal-user {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.portal-user h3 {
+  color: #fff;
+}
+
+.portal-user-role {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(122, 201, 255, 0.8);
+}
+
+.portal-menu {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.portal-menu-link {
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(122, 201, 255, 0.15);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.portal-menu-link.active,
+.portal-menu-link:hover {
+  background: rgba(122, 201, 255, 0.18);
+  border-color: rgba(122, 201, 255, 0.4);
+  color: #fff;
+}
+
+.portal-sidebar-footer {
+  display: grid;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.portal-content {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.portal-view-header {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.portal-view-header h2 {
+  font-size: clamp(1.6rem, 3vw, 2rem);
+}
+
+.portal-view-header p {
+  color: var(--text-muted);
+}
+
+.portal-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
+}
+
+.metric-card {
+  background: #fff;
+  border-radius: 20px;
+  padding: 1.6rem;
+  box-shadow: 0 20px 40px rgba(10, 27, 42, 0.08);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.metric-card h3 {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.metric-value {
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.metric-trend {
+  font-size: 0.9rem;
+  color: #1f9254;
+}
+
+.portal-panels {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.portal-panel {
+  background: #fff;
+  border-radius: 20px;
+  padding: 1.6rem;
+  box-shadow: 0 20px 40px rgba(10, 27, 42, 0.08);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.portal-panel header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.portal-panel header h3 {
+  font-size: 1.1rem;
+}
+
+.portal-panel header span {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.activity-feed,
+.task-list {
+  list-style: none;
+  display: grid;
+  gap: 1.1rem;
+}
+
+.activity-feed li,
+.task-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.activity-feed li {
+  flex-direction: column;
+}
+
+.feed-title {
+  font-weight: 600;
+}
+
+.feed-time {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.task-priority {
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  align-self: center;
+}
+
+.task-high {
+  background: rgba(211, 63, 73, 0.12);
+  color: #d33f49;
+}
+
+.task-medium {
+  background: rgba(247, 183, 51, 0.18);
+  color: #c47f11;
+}
+
+.task-low {
+  background: rgba(48, 209, 88, 0.18);
+  color: #1f9254;
+}
+
+.portal-form {
+  background: #fff;
+  border-radius: 20px;
+  padding: clamp(1.6rem, 3vw, 2rem);
+  box-shadow: 0 20px 40px rgba(10, 27, 42, 0.08);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.input-help {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.switch {
+  position: relative;
+  width: 52px;
+  height: 28px;
+  display: inline-block;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(10, 27, 42, 0.2);
+  transition: 0.3s;
+  border-radius: 999px;
+}
+
+.slider::before {
+  position: absolute;
+  content: '';
+  height: 20px;
+  width: 20px;
+  left: 4px;
+  bottom: 4px;
+  background-color: #fff;
+  transition: 0.3s;
+  border-radius: 50%;
+  box-shadow: 0 2px 6px rgba(10, 27, 42, 0.25);
+}
+
+.switch input:checked + .slider {
+  background-color: rgba(122, 201, 255, 0.8);
+}
+
+.switch input:checked + .slider::before {
+  transform: translateX(24px);
+}
+
+.security-panel {
+  background: #fff;
+}
+
+.portal-body.portal-authenticated .portal-auth {
+  display: none;
+}
+
+.portal-body.portal-authenticated .portal-main {
+  margin-top: -6rem;
+}
+
+@media (max-width: 960px) {
+  .portal-main {
+    margin-top: -2rem;
+    padding-bottom: 4rem;
+  }
+
+  .portal-auth {
+    transform: translateY(-30%);
+  }
+
+  .portal-app {
+    grid-template-columns: 1fr;
+  }
+
+  .portal-sidebar {
+    position: relative;
+    padding: 1.5rem;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .portal-hero-card {
+    margin-top: 2rem;
+  }
+
+  .portal-auth {
+    transform: none;
+    margin-top: -2rem;
+  }
+
+  .portal-main {
+    margin-top: -1rem;
+    padding-inline: clamp(1rem, 6vw, 1.5rem);
+  }
+
+  .portal-body.portal-authenticated .portal-main {
+    margin-top: -2rem;
   }
 }

--- a/public/testimonials.html
+++ b/public/testimonials.html
@@ -24,6 +24,7 @@
             <a href="testimonials.html" data-page="testimonials">Testimonials</a>
           </li>
           <li><a href="contact.html" data-page="contact">Contact</a></li>
+          <li><a href="portal.html" data-page="portal">Portal</a></li>
         </ul>
         <a href="contact.html" class="btn btn-outline">Request Proposal</a>
       </nav>
@@ -202,6 +203,12 @@
           <p>hello@summitpm.com</p>
           <p>+1 (312) 555-0198</p>
           <p>123 Skyline Avenue, Suite 1800, Chicago, IL</p>
+        </div>
+        <div class="footer-portal">
+          <h4>Client portal</h4>
+          <p>Already onboarded? Manage assets and communications securely.</p>
+          <a href="portal.html" class="btn btn-primary footer-login">Access portal</a>
+          <span class="portal-support">Need help? Email support@summitpm.com</span>
         </div>
       </div>
       <p class="footer-bottom">© <span id="year"></span> Summit Property Management. All rights reserved.</p>


### PR DESCRIPTION
## Summary
- add a dedicated portal page with login, signup, password reset, and a post-login dashboard
- persist mock authentication, notification preferences, and site settings updates via local storage helpers
- surface portal entry points in the site navigation and footer so clients can reach the secure area from any page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d46572b38c8322a1828cccd918cdc7