### PR TITLE
Enhance SEO metadata and add crawl assets

### DIFF
--- a/public/contact.html
+++ b/public/contact.html
@@ -3,7 +3,44 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Connect with Summit Property Management's Chicago headquarters to request proposals, schedule consultations, or access owner support."
+    />
+    <meta
+      name="keywords"
+      content="contact Summit Property Management, property management consultation, Chicago property managers contact"
+    />
+    <meta name="author" content="Summit Property Management" />
+    <meta name="robots" content="index, follow" />
     <title>Contact | Summit Property Management</title>
+    <link rel="canonical" href="https://www.summitpm.com/contact" />
+    <link rel="alternate" href="https://www.summitpm.com/contact" hreflang="en" />
+    <meta property="og:type" content="article" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="Summit Property Management" />
+    <meta property="og:url" content="https://www.summitpm.com/contact" />
+    <meta property="og:title" content="Contact Summit Property Management" />
+    <meta
+      property="og:description"
+      content="Request a consultation or connect with SummitPM's property experts for tailored asset strategies."
+    />
+    <meta
+      property="og:image"
+      content="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1200&q=80"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@SummitPM" />
+    <meta name="twitter:creator" content="@SummitPM" />
+    <meta name="twitter:title" content="Connect with SummitPM" />
+    <meta
+      name="twitter:description"
+      content="Reach Summit Property Management's hospitality-driven team to discuss your portfolio goals."
+    />
+    <meta
+      name="twitter:image"
+      content="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1200&q=80"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -12,6 +49,45 @@
     />
     <link rel="stylesheet" href="https://s.pageclip.co/v1/pageclip.css" media="screen" />
     <link rel="stylesheet" href="styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://www.summitpm.com/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Contact",
+            "item": "https://www.summitpm.com/contact"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "ContactPage",
+        "name": "Contact Summit Property Management",
+        "url": "https://www.summitpm.com/contact",
+        "mainEntity": {
+          "@type": "Organization",
+          "name": "Summit Property Management",
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "telephone": "+1-312-555-0198",
+            "contactType": "customer service",
+            "areaServed": "US",
+            "availableLanguage": ["English"]
+          }
+        }
+      }
+    </script>
   </head>
   <body data-page="contact">
     <header class="hero page-hero">

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,51 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Summit Property Management delivers luxury residential and commercial property management in Chicago with hospitality-driven service, data-backed strategy, and visionary design."
+    />
+    <meta
+      name="keywords"
+      content="Summit Property Management, Chicago property management, luxury property management, commercial property services, residential property managers"
+    />
+    <meta name="author" content="Summit Property Management" />
+    <meta name="robots" content="index, follow" />
+    <meta name="theme-color" content="#0e1b4d" />
     <title>Summit Property Management</title>
+    <link rel="canonical" href="https://www.summitpm.com/" />
+    <link rel="alternate" href="https://www.summitpm.com/" hreflang="en" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="Summit Property Management" />
+    <meta property="og:url" content="https://www.summitpm.com/" />
+    <meta
+      property="og:title"
+      content="Summit Property Management | Elevated Property Operations"
+    />
+    <meta
+      property="og:description"
+      content="Experience hospitality-driven property management that maximizes asset value through data insights, concierge service, and design-forward execution."
+    />
+    <meta
+      property="og:image"
+      content="https://images.unsplash.com/photo-1469796466635-455ede028aca?auto=format&fit=crop&w=1200&q=80"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@SummitPM" />
+    <meta name="twitter:creator" content="@SummitPM" />
+    <meta
+      name="twitter:title"
+      content="Summit Property Management | Elevated Property Operations"
+    />
+    <meta
+      name="twitter:description"
+      content="Discover Summit Property Management's hospitality-led residential and commercial property services in Chicago."
+    />
+    <meta
+      name="twitter:image"
+      content="https://images.unsplash.com/photo-1469796466635-455ede028aca?auto=format&fit=crop&w=1200&q=80"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -11,6 +55,49 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "LocalBusiness",
+        "name": "Summit Property Management",
+        "image": "https://images.unsplash.com/photo-1469796466635-455ede028aca?auto=format&fit=crop&w=1200&q=80",
+        "@id": "https://www.summitpm.com#organization",
+        "url": "https://www.summitpm.com/",
+        "telephone": "+1-312-555-0198",
+        "priceRange": "$$$",
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "123 Skyline Avenue, Suite 1800",
+          "addressLocality": "Chicago",
+          "addressRegion": "IL",
+          "postalCode": "60601",
+          "addressCountry": "US"
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": "41.881832",
+          "longitude": "-87.623177"
+        },
+        "sameAs": [
+          "https://www.linkedin.com/company/summitpm",
+          "https://www.facebook.com/summitpm",
+          "https://www.instagram.com/summitpm"
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Summit Property Management",
+        "url": "https://www.summitpm.com/",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "https://www.summitpm.com/?s={search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
   </head>
   <body data-page="home">
     <header class="hero">

--- a/public/portal.html
+++ b/public/portal.html
@@ -3,7 +3,33 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta
+      name="description"
+      content="Secure login area for Summit Property Management clients and residents to access dashboards, documents, and communications."
+    />
+    <meta name="author" content="Summit Property Management" />
     <title>Client Portal | Summit Property Management</title>
+    <link rel="canonical" href="https://www.summitpm.com/portal" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="Summit Property Management" />
+    <meta property="og:url" content="https://www.summitpm.com/portal" />
+    <meta property="og:title" content="SummitPM Client Portal" />
+    <meta
+      property="og:description"
+      content="Log in to the SummitPM portal for real-time property performance, maintenance tracking, and communications."
+    />
+    <meta
+      property="og:image"
+      content="https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80"
+    />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="SummitPM Client Portal" />
+    <meta
+      name="twitter:description"
+      content="Access your Summit Property Management dashboard to monitor performance and resident experience."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -3,7 +3,47 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Tour Summit Property Management's portfolio of luxury residential towers, mixed-use developments, and revitalized commercial spaces across Chicago."
+    />
+    <meta
+      name="keywords"
+      content="property management portfolio, luxury buildings Chicago, commercial property showcase, Summit Property Management"
+    />
+    <meta name="author" content="Summit Property Management" />
+    <meta name="robots" content="index, follow" />
     <title>Portfolio | Summit Property Management</title>
+    <link rel="canonical" href="https://www.summitpm.com/portfolio" />
+    <link rel="alternate" href="https://www.summitpm.com/portfolio" hreflang="en" />
+    <meta property="og:type" content="article" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="Summit Property Management" />
+    <meta property="og:url" content="https://www.summitpm.com/portfolio" />
+    <meta
+      property="og:title"
+      content="Summit Property Management Portfolio"
+    />
+    <meta
+      property="og:description"
+      content="Explore recent property transformations and high-performing assets managed by Summit Property Management."
+    />
+    <meta
+      property="og:image"
+      content="https://images.unsplash.com/photo-1529429617124-aee0a9429e5a?auto=format&fit=crop&w=1200&q=80"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@SummitPM" />
+    <meta name="twitter:creator" content="@SummitPM" />
+    <meta name="twitter:title" content="SummitPM Property Portfolio" />
+    <meta
+      name="twitter:description"
+      content="See how SummitPM elevates residential and commercial properties through hospitality-driven management."
+    />
+    <meta
+      name="twitter:image"
+      content="https://images.unsplash.com/photo-1529429617124-aee0a9429e5a?auto=format&fit=crop&w=1200&q=80"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -11,6 +51,39 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://www.summitpm.com/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Portfolio",
+            "item": "https://www.summitpm.com/portfolio"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "Summit Property Management Portfolio",
+        "about": "Curated showcase of luxury residential, mixed-use, and commercial properties managed by Summit Property Management.",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Summit Property Management",
+          "url": "https://www.summitpm.com/"
+        }
+      }
+    </script>
   </head>
   <body data-page="portfolio">
     <header class="hero page-hero">

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Disallow: /portal.html
+Disallow: /portal
+Allow: /
+
+Sitemap: https://www.summitpm.com/sitemap.xml

--- a/public/services.html
+++ b/public/services.html
@@ -3,7 +3,47 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Explore Summit Property Management's full suite of property operations, asset strategy, and lifestyle programming services tailored for luxury residential and commercial portfolios."
+    />
+    <meta
+      name="keywords"
+      content="property management services, asset strategy, facilities management, hospitality operations, Summit Property Management"
+    />
+    <meta name="author" content="Summit Property Management" />
+    <meta name="robots" content="index, follow" />
     <title>Services | Summit Property Management</title>
+    <link rel="canonical" href="https://www.summitpm.com/services" />
+    <link rel="alternate" href="https://www.summitpm.com/services" hreflang="en" />
+    <meta property="og:type" content="article" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="Summit Property Management" />
+    <meta property="og:url" content="https://www.summitpm.com/services" />
+    <meta
+      property="og:title"
+      content="Summit Property Management Services"
+    />
+    <meta
+      property="og:description"
+      content="Discover the hospitality-driven property management, asset optimization, and sustainability services that keep iconic properties thriving."
+    />
+    <meta
+      property="og:image"
+      content="https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?auto=format&fit=crop&w=1200&q=80"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@SummitPM" />
+    <meta name="twitter:creator" content="@SummitPM" />
+    <meta name="twitter:title" content="SummitPM Property Management Services" />
+    <meta
+      name="twitter:description"
+      content="See how SummitPM blends hospitality, technology, and finance to manage luxury real estate portfolios."
+    />
+    <meta
+      name="twitter:image"
+      content="https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?auto=format&fit=crop&w=1200&q=80"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -11,6 +51,44 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://www.summitpm.com/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Services",
+            "item": "https://www.summitpm.com/services"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Service",
+        "name": "Summit Property Management Services",
+        "provider": {
+          "@type": "Organization",
+          "name": "Summit Property Management",
+          "url": "https://www.summitpm.com/"
+        },
+        "areaServed": {
+          "@type": "Place",
+          "name": "Chicago, IL"
+        },
+        "serviceType": "Luxury Residential and Commercial Property Management",
+        "description": "Operations, asset strategy, and hospitality programming services designed to maximize property value and tenant satisfaction."
+      }
+    </script>
   </head>
   <body data-page="services">
     <header class="hero page-hero">

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.summitpm.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.summitpm.com/services</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.summitpm.com/portfolio</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.summitpm.com/testimonials</loc>
+    <changefreq>quarterly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.summitpm.com/contact</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.summitpm.com/portal</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.1</priority>
+  </url>
+</urlset>

--- a/public/testimonials.html
+++ b/public/testimonials.html
@@ -3,7 +3,47 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="See why developers and investors trust Summit Property Management through testimonials that spotlight hospitality-driven service, transparent reporting, and performance gains."
+    />
+    <meta
+      name="keywords"
+      content="property management reviews, Summit Property Management testimonials, client feedback, luxury property management Chicago"
+    />
+    <meta name="author" content="Summit Property Management" />
+    <meta name="robots" content="index, follow" />
     <title>Testimonials | Summit Property Management</title>
+    <link rel="canonical" href="https://www.summitpm.com/testimonials" />
+    <link rel="alternate" href="https://www.summitpm.com/testimonials" hreflang="en" />
+    <meta property="og:type" content="article" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="Summit Property Management" />
+    <meta property="og:url" content="https://www.summitpm.com/testimonials" />
+    <meta
+      property="og:title"
+      content="Summit Property Management Testimonials"
+    />
+    <meta
+      property="og:description"
+      content="Hear from owners and investors partnering with SummitPM for high-performing properties and memorable tenant experiences."
+    />
+    <meta
+      property="og:image"
+      content="https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?auto=format&fit=crop&w=1200&q=80"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@SummitPM" />
+    <meta name="twitter:creator" content="@SummitPM" />
+    <meta name="twitter:title" content="SummitPM Client Testimonials" />
+    <meta
+      name="twitter:description"
+      content="Developers and investors share how SummitPM elevates asset value and resident satisfaction."
+    />
+    <meta
+      name="twitter:image"
+      content="https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?auto=format&fit=crop&w=1200&q=80"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -11,6 +51,47 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://www.summitpm.com/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Testimonials",
+            "item": "https://www.summitpm.com/testimonials"
+          }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Review",
+        "itemReviewed": {
+          "@type": "Organization",
+          "name": "Summit Property Management"
+        },
+        "reviewRating": {
+          "@type": "Rating",
+          "ratingValue": "4.9",
+          "bestRating": "5"
+        },
+        "name": "SummitPM Client Feedback",
+        "author": {
+          "@type": "Organization",
+          "name": "Summit Property Management"
+        },
+        "reviewBody": "Developers and investors praise Summit Property Management for concierge-level service, transparent reporting, and consistently high occupancy."
+      }
+    </script>
   </head>
   <body data-page="testimonials">
     <header class="hero page-hero">


### PR DESCRIPTION
## Summary
- enrich every public page with descriptive meta tags, Open Graph/Twitter cards, canonical URLs, and structured data tuned for property management keywords
- add page-specific JSON-LD for organization, services, reviews, and breadcrumbs to improve search snippets and entity understanding
- introduce robots.txt and sitemap.xml to guide crawlers toward high-value pages while excluding the secure portal

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d467f5e1b48322a97898ef0c25d0f2