### PR TITLE
Adjust portal spacing to avoid hero overlap

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -798,7 +798,7 @@ textarea:focus {
 }
 
 .portal-main {
-  margin-top: -4rem;
+  margin-top: clamp(-3.5rem, -8vw, -2rem);
   padding: 0 clamp(1.5rem, 5vw, 4rem) 5rem;
   position: relative;
   z-index: 2;
@@ -806,8 +806,7 @@ textarea:focus {
 
 .portal-auth {
   max-width: 420px;
-  margin: 0 auto;
-  transform: translateY(-50%);
+  margin: clamp(-2.5rem, -6vw, -1rem) auto 0;
 }
 
 .portal-card {
@@ -1183,7 +1182,7 @@ textarea:focus {
   }
 
   .portal-auth {
-    transform: translateY(-30%);
+    margin-top: -1.5rem;
   }
 
   .portal-app {
@@ -1204,8 +1203,7 @@ textarea:focus {
   }
 
   .portal-auth {
-    transform: none;
-    margin-top: -2rem;
+    margin-top: -1rem;
   }
 
   .portal-main {


### PR DESCRIPTION
## Summary
- relax the negative offset on the portal main section so the login card no longer collides with the hero benefits card
- replace the translate-based offset on the portal auth container with responsive margin controls for consistent spacing across breakpoints
- tweak responsive breakpoints to keep comfortable spacing on tablets and phones

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d468a04c908322b831e9d1ddace726