### PR TITLE
Embed Aptly contact form on contact page

### DIFF
--- a/public/contact.html
+++ b/public/contact.html
@@ -47,6 +47,16 @@
             <p>W: <a href="https://livingsimpleproperties.com/" target="_blank" rel="noreferrer">www.livingsimpleproperties.com</a></p>
             <p>P: <a href="tel:+12402588817">240.258.8817</a></p>
           </div>
+          <div class="card">
+            <h2>Contact Form</h2>
+            <iframe
+              src="https://portal.getaptly.com/form/oqxDoTjcYBXThSTQB/new/cp4D2nkeASMiKu5P3"
+              width="100%"
+              height="600"
+              frameborder="0"
+              allowfullscreen
+            ></iframe>
+          </div>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add an embedded iframe contact form to the contact page so visitors can submit inquiries online
- size the iframe to use the full card width and provide ample height for the form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d83562063c8322875fc54d311cb3d8