### PR TITLE
Adjust rental report form header color

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -244,6 +244,15 @@ img {
   box-shadow: var(--shadow-soft);
 }
 
+.form-card h1,
+.form-card h2,
+.form-card h3,
+.form-card h4,
+.form-card h5,
+.form-card h6 {
+  color: #000000;
+}
+
 form {
   display: grid;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- ensure headings inside the rental report form card render in black for improved contrast on the light background

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d843b9c780833289174745b909f6f0