### PR TITLE
Apply LivingSimple branding refresh

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -8,19 +8,24 @@
       name="description"
       content="Learn about Atwan and the LivingSimple Properties story—decades of hands-on experience helping Rockville-area investors save time and money through responsive, first-name-basis management."
     />
+    <meta name="theme-color" content="#8DD50C" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="icon" type="image/svg+xml" href="images/livingsimple-favicon.svg" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body data-page="about">
     <div class="top-bar">Call Us at <a href="tel:+12402588817">+1 (240) 258-8817</a></div>
     <header class="site-header">
       <nav class="navbar">
-        <a class="brand" href="index.html">LivingSimple <span>Properties</span></a>
+        <a class="brand" href="index.html" aria-label="LivingSimple Properties home">
+          <img class="brand-logo" src="images/livingsimple-logo.svg" alt="" />
+          <span class="sr-only">LivingSimple Properties</span>
+        </a>
         <ul class="nav-links">
           <li><a href="index.html" data-page="home">Home</a></li>
           <li><a href="about.html" data-page="about">About</a></li>
@@ -97,6 +102,7 @@
       <div class="container">
         <div class="footer-grid">
           <div>
+            <img class="footer-logo" src="images/livingsimple-logo.svg" alt="LivingSimple Properties" />
             <h4>Say Hiiiii on Facebook!</h4>
             <p>
               Join the conversation with LivingSimple Properties for neighborhood tips and rental updates.

--- a/public/blog.html
+++ b/public/blog.html
@@ -8,19 +8,24 @@
       name="description"
       content="Read the LivingSimple Properties blog, including the Under Construction update originally posted April 12, 2016."
     />
+    <meta name="theme-color" content="#8DD50C" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="icon" type="image/svg+xml" href="images/livingsimple-favicon.svg" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body data-page="blog">
     <div class="top-bar">Call Us at <a href="tel:+12402588817">+1 (240) 258-8817</a></div>
     <header class="site-header">
       <nav class="navbar">
-        <a class="brand" href="index.html">LivingSimple <span>Properties</span></a>
+        <a class="brand" href="index.html" aria-label="LivingSimple Properties home">
+          <img class="brand-logo" src="images/livingsimple-logo.svg" alt="" />
+          <span class="sr-only">LivingSimple Properties</span>
+        </a>
         <ul class="nav-links">
           <li><a href="index.html" data-page="home">Home</a></li>
           <li><a href="about.html" data-page="about">About</a></li>
@@ -96,6 +101,7 @@
       <div class="container">
         <div class="footer-grid">
           <div>
+            <img class="footer-logo" src="images/livingsimple-logo.svg" alt="LivingSimple Properties" />
             <h4>Say Hiiiii on Facebook!</h4>
             <p>
               Join the conversation with LivingSimple Properties for neighborhood tips and rental updates.

--- a/public/contact.html
+++ b/public/contact.html
@@ -8,19 +8,24 @@
       name="description"
       content="Contact LivingSimple Properties at 500 N. Washington St. #1021, Rockville, MD 20850 or call 240.258.8817 for responsive property management support."
     />
+    <meta name="theme-color" content="#8DD50C" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="icon" type="image/svg+xml" href="images/livingsimple-favicon.svg" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body data-page="contact">
     <div class="top-bar">Call Us at <a href="tel:+12402588817">+1 (240) 258-8817</a></div>
     <header class="site-header">
       <nav class="navbar">
-        <a class="brand" href="index.html">LivingSimple <span>Properties</span></a>
+        <a class="brand" href="index.html" aria-label="LivingSimple Properties home">
+          <img class="brand-logo" src="images/livingsimple-logo.svg" alt="" />
+          <span class="sr-only">LivingSimple Properties</span>
+        </a>
         <ul class="nav-links">
           <li><a href="index.html" data-page="home">Home</a></li>
           <li><a href="about.html" data-page="about">About</a></li>
@@ -65,6 +70,7 @@
       <div class="container">
         <div class="footer-grid">
           <div>
+            <img class="footer-logo" src="images/livingsimple-logo.svg" alt="LivingSimple Properties" />
             <h4>Say Hiiiii on Facebook!</h4>
             <p>
               Join the conversation with LivingSimple Properties for neighborhood tips and rental updates.

--- a/public/guarantee.html
+++ b/public/guarantee.html
@@ -8,19 +8,24 @@
       name="description"
       content="Review LivingSimple Properties Lease Guarantee and Eviction Assurance, copied directly from the livingsimpleproperties.com guarantee page."
     />
+    <meta name="theme-color" content="#8DD50C" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="icon" type="image/svg+xml" href="images/livingsimple-favicon.svg" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body data-page="guarantee">
     <div class="top-bar">Call Us at <a href="tel:+12402588817">+1 (240) 258-8817</a></div>
     <header class="site-header">
       <nav class="navbar">
-        <a class="brand" href="index.html">LivingSimple <span>Properties</span></a>
+        <a class="brand" href="index.html" aria-label="LivingSimple Properties home">
+          <img class="brand-logo" src="images/livingsimple-logo.svg" alt="" />
+          <span class="sr-only">LivingSimple Properties</span>
+        </a>
         <ul class="nav-links">
           <li><a href="index.html" data-page="home">Home</a></li>
           <li><a href="about.html" data-page="about">About</a></li>
@@ -63,6 +68,7 @@
       <div class="container">
         <div class="footer-grid">
           <div>
+            <img class="footer-logo" src="images/livingsimple-logo.svg" alt="LivingSimple Properties" />
             <h4>Say Hiiiii on Facebook!</h4>
             <p>
               Join the conversation with LivingSimple Properties for neighborhood tips and rental updates.

--- a/public/images/livingsimple-favicon.svg
+++ b/public/images/livingsimple-favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">LivingSimple Properties icon</title>
+  <circle cx="64" cy="64" r="58" fill="none" stroke="#8DD50C" stroke-width="10" />
+  <path
+    d="M64 22 100 44v48l-36 22-36-22V44Z"
+    fill="none"
+    stroke="#8DD50C"
+    stroke-width="10"
+    stroke-linejoin="round"
+  />
+  <rect x="50" y="50" width="28" height="28" fill="none" stroke="#8DD50C" stroke-width="8" />
+  <line x1="64" y1="50" x2="64" y2="78" stroke="#8DD50C" stroke-width="8" />
+  <line x1="50" y1="64" x2="78" y2="64" stroke="#8DD50C" stroke-width="8" />
+</svg>

--- a/public/images/livingsimple-logo.svg
+++ b/public/images/livingsimple-logo.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 140" role="img" aria-labelledby="title desc">
+  <title id="title">LivingSimple Properties logo</title>
+  <desc id="desc">A green house icon inside a circle with the words living simple properties.</desc>
+  <g transform="translate(0 0)">
+    <circle cx="70" cy="70" r="60" fill="none" stroke="#8DD50C" stroke-width="8" />
+    <path
+      d="M70 30L113 56v52l-43 26-43-26V56Z"
+      fill="none"
+      stroke="#8DD50C"
+      stroke-width="8"
+      stroke-linejoin="round"
+    />
+    <rect x="56" y="56" width="28" height="28" fill="none" stroke="#8DD50C" stroke-width="6" />
+    <line x1="70" y1="56" x2="70" y2="84" stroke="#8DD50C" stroke-width="6" />
+    <line x1="56" y1="70" x2="84" y2="70" stroke="#8DD50C" stroke-width="6" />
+  </g>
+  <text x="150" y="78" font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="42">
+    <tspan fill="#5f5f5f" font-weight="400">living</tspan>
+    <tspan dx="12" fill="#202020" font-weight="700">simple</tspan>
+  </text>
+  <text x="150" y="110" font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="16" font-weight="600" letter-spacing="0.5em" fill="#5f5f5f">
+    PROPERTIES
+  </text>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -9,19 +9,24 @@
       content="LivingSimple Properties delivers first-name-basis property management across Rockville, Gaithersburg, Bethesda, and NW Washington DC with responsive service, thorough screening, and guaranteed results."
     />
     <meta name="robots" content="index, follow" />
+    <meta name="theme-color" content="#8DD50C" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="icon" type="image/svg+xml" href="images/livingsimple-favicon.svg" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body data-page="home">
     <div class="top-bar">Call Us at <a href="tel:+12402588817">+1 (240) 258-8817</a></div>
     <header class="site-header">
       <nav class="navbar">
-        <a class="brand" href="index.html">LivingSimple <span>Properties</span></a>
+        <a class="brand" href="index.html" aria-label="LivingSimple Properties home">
+          <img class="brand-logo" src="images/livingsimple-logo.svg" alt="" />
+          <span class="sr-only">LivingSimple Properties</span>
+        </a>
         <ul class="nav-links">
           <li><a href="index.html" data-page="home">Home</a></li>
           <li><a href="about.html" data-page="about">About</a></li>
@@ -38,6 +43,7 @@
       <section class="hero">
         <div class="container">
           <div>
+            <img class="hero-logo" src="images/livingsimple-favicon.svg" alt="LivingSimple Properties icon" />
             <span class="badge">Rockville Property Management</span>
             <h1>A First Name Basis Property Management Business</h1>
             <p class="subheading">(serving Gaithersburg, Rockville, Bethesda and NW Washington DC)</p>
@@ -194,6 +200,7 @@
       <div class="container">
         <div class="footer-grid">
           <div>
+            <img class="footer-logo" src="images/livingsimple-logo.svg" alt="LivingSimple Properties" />
             <h4>Say Hiiiii on Facebook!</h4>
             <p>
               Join the conversation with LivingSimple Properties for neighborhood tips and rental updates.

--- a/public/listings.html
+++ b/public/listings.html
@@ -8,19 +8,24 @@
       name="description"
       content="Browse LivingSimple Properties listings featuring Rockville, Gaithersburg, Olney, and Germantown homes—each described exactly as showcased on livingsimpleproperties.com."
     />
+    <meta name="theme-color" content="#8DD50C" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="icon" type="image/svg+xml" href="images/livingsimple-favicon.svg" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body data-page="listings">
     <div class="top-bar">Call Us at <a href="tel:+12402588817">+1 (240) 258-8817</a></div>
     <header class="site-header">
       <nav class="navbar">
-        <a class="brand" href="index.html">LivingSimple <span>Properties</span></a>
+        <a class="brand" href="index.html" aria-label="LivingSimple Properties home">
+          <img class="brand-logo" src="images/livingsimple-logo.svg" alt="" />
+          <span class="sr-only">LivingSimple Properties</span>
+        </a>
         <ul class="nav-links">
           <li><a href="index.html" data-page="home">Home</a></li>
           <li><a href="about.html" data-page="about">About</a></li>
@@ -102,6 +107,7 @@
       <div class="container">
         <div class="footer-grid">
           <div>
+            <img class="footer-logo" src="images/livingsimple-logo.svg" alt="LivingSimple Properties" />
             <h4>Say Hiiiii on Facebook!</h4>
             <p>
               Join the conversation with LivingSimple Properties for neighborhood tips and rental updates.

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -8,19 +8,24 @@
       name="description"
       content="Explore LivingSimple Properties pricing plans—from one-time leasing support to full-service management—each designed to protect your rental while honoring your priorities."
     />
+    <meta name="theme-color" content="#8DD50C" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="icon" type="image/svg+xml" href="images/livingsimple-favicon.svg" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body data-page="pricing">
     <div class="top-bar">Call Us at <a href="tel:+12402588817">+1 (240) 258-8817</a></div>
     <header class="site-header">
       <nav class="navbar">
-        <a class="brand" href="index.html">LivingSimple <span>Properties</span></a>
+        <a class="brand" href="index.html" aria-label="LivingSimple Properties home">
+          <img class="brand-logo" src="images/livingsimple-logo.svg" alt="" />
+          <span class="sr-only">LivingSimple Properties</span>
+        </a>
         <ul class="nav-links">
           <li><a href="index.html" data-page="home">Home</a></li>
           <li><a href="about.html" data-page="about">About</a></li>
@@ -96,6 +101,7 @@
       <div class="container">
         <div class="footer-grid">
           <div>
+            <img class="footer-logo" src="images/livingsimple-logo.svg" alt="LivingSimple Properties" />
             <h4>Say Hiiiii on Facebook!</h4>
             <p>
               Join the conversation with LivingSimple Properties for neighborhood tips and rental updates.

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,13 +1,13 @@
 :root {
-  --brand-green: #1f4d3a;
-  --brand-dark: #0f2019;
-  --brand-gold: #d9a441;
-  --brand-cream: #f7f5f0;
+  --brand-primary: #8dd50c;
+  --brand-primary-dark: #76b50a;
+  --brand-deep: #101d01;
+  --brand-surface: #f5fbe8;
   --brand-white: #ffffff;
-  --text-body: #2f3b32;
-  --text-muted: #5c6a63;
-  --border: rgba(31, 77, 58, 0.16);
-  --shadow-soft: 0 16px 36px rgba(15, 32, 25, 0.08);
+  --text-body: #1b2614;
+  --text-muted: #56624c;
+  --border: rgba(16, 29, 1, 0.14);
+  --shadow-soft: 0 16px 36px rgba(16, 29, 1, 0.08);
   --max-width: 1100px;
 }
 
@@ -20,7 +20,7 @@
 body {
   font-family: 'Poppins', sans-serif;
   color: var(--text-body);
-  background: var(--brand-cream);
+  background: var(--brand-surface);
   line-height: 1.7;
 }
 
@@ -35,11 +35,16 @@ img {
 }
 
 .top-bar {
-  background: var(--brand-dark);
+  background: var(--brand-deep);
   color: var(--brand-white);
   font-size: 0.9rem;
   padding: 0.6rem 1.5rem;
   text-align: center;
+}
+
+.top-bar a {
+  color: var(--brand-primary);
+  font-weight: 600;
 }
 
 .site-header {
@@ -58,17 +63,15 @@ img {
 }
 
 .brand {
-  font-weight: 700;
-  font-size: 1.3rem;
-  color: var(--brand-green);
-  letter-spacing: 0.04em;
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.75rem;
+  text-decoration: none;
 }
 
-.brand span {
-  color: var(--brand-gold);
+.brand-logo {
+  height: 52px;
+  width: auto;
 }
 
 .nav-links {
@@ -87,8 +90,8 @@ img {
 
 .nav-links a:hover,
 .nav-links a.active {
-  color: var(--brand-green);
-  border-color: var(--brand-gold);
+  color: var(--brand-primary);
+  border-color: var(--brand-primary);
 }
 
 .btn {
@@ -103,12 +106,12 @@ img {
 }
 
 .btn-primary {
-  background: var(--brand-gold);
-  color: var(--brand-dark);
+  background: var(--brand-primary);
+  color: var(--brand-deep);
 }
 
 .btn-primary:hover {
-  background: #e4b753;
+  background: var(--brand-primary-dark);
 }
 
 .btn-outline {
@@ -121,19 +124,24 @@ img {
 }
 
 .btn-ghost {
-  border-color: var(--brand-green);
-  color: var(--brand-green);
+  border-color: var(--brand-primary);
+  color: var(--brand-primary);
 }
 
 .btn-ghost:hover {
-  background: rgba(31, 77, 58, 0.08);
+  background: rgba(141, 213, 12, 0.12);
 }
 
 .hero {
-  background: linear-gradient(rgba(15, 32, 25, 0.75), rgba(15, 32, 25, 0.75)),
+  background: linear-gradient(rgba(16, 29, 1, 0.82), rgba(16, 29, 1, 0.88)),
     url('https://livingsimpleproperties.com/wp-content/uploads/2016/06/3rdbrfurniturenochest.jpg')
       center/cover no-repeat;
   color: var(--brand-white);
+}
+
+.hero-logo {
+  width: 76px;
+  margin-bottom: 1.25rem;
 }
 
 .hero .container {
@@ -162,7 +170,7 @@ img {
   font-size: 0.95rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--brand-gold);
+  color: var(--brand-primary);
   margin-bottom: 1rem;
   display: inline-block;
 }
@@ -194,7 +202,7 @@ img {
 .section-header h1,
 .section-header h2 {
   font-size: clamp(2rem, 4vw, 2.6rem);
-  color: var(--brand-green);
+  color: var(--brand-primary);
   margin-bottom: 0.75rem;
 }
 
@@ -224,13 +232,13 @@ img {
   border-radius: 18px;
   padding: 1.75rem;
   box-shadow: var(--shadow-soft);
-  border: 1px solid rgba(15, 32, 25, 0.05);
+  border: 1px solid rgba(16, 29, 1, 0.08);
 }
 
 .card h3 {
   font-size: 1.35rem;
   margin-bottom: 0.6rem;
-  color: var(--brand-green);
+  color: var(--brand-primary);
 }
 
 .card p {
@@ -268,15 +276,15 @@ textarea {
   font: inherit;
   padding: 0.75rem 1rem;
   border-radius: 12px;
-  border: 1px solid rgba(31, 77, 58, 0.25);
-  background: var(--brand-cream);
+  border: 1px solid rgba(141, 213, 12, 0.35);
+  background: var(--brand-surface);
   transition: border-color 0.2s ease, background 0.2s ease;
 }
 
 input:focus,
 textarea:focus {
   outline: none;
-  border-color: var(--brand-green);
+  border-color: var(--brand-primary);
   background: var(--brand-white);
 }
 
@@ -292,7 +300,7 @@ textarea {
 
 .testimonial {
   background: var(--brand-white);
-  border-left: 4px solid var(--brand-gold);
+  border-left: 4px solid var(--brand-primary);
   padding: 1.5rem 1.75rem;
   border-radius: 16px;
   box-shadow: var(--shadow-soft);
@@ -304,7 +312,7 @@ textarea {
 }
 
 .testimonial strong {
-  color: var(--brand-green);
+  color: var(--brand-primary);
 }
 
 .listings {
@@ -316,17 +324,17 @@ textarea {
   background: var(--brand-white);
   border-radius: 16px;
   padding: 1.5rem;
-  border: 1px solid rgba(15, 32, 25, 0.08);
+  border: 1px solid rgba(16, 29, 1, 0.08);
   box-shadow: var(--shadow-soft);
 }
 
 .listing h3 {
-  color: var(--brand-green);
+  color: var(--brand-primary);
   margin-bottom: 0.35rem;
 }
 
 .footer {
-  background: var(--brand-dark);
+  background: var(--brand-deep);
   color: rgba(255, 255, 255, 0.88);
   padding: 3rem 1.5rem 2rem;
 }
@@ -345,7 +353,7 @@ textarea {
 
 .footer h4 {
   font-size: 1.1rem;
-  color: var(--brand-gold);
+  color: var(--brand-primary);
   margin-bottom: 1rem;
 }
 
@@ -375,6 +383,23 @@ textarea {
   font-size: 0.9rem;
 }
 
+.footer-logo {
+  width: 160px;
+  margin-bottom: 1rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 main p + p {
   margin-top: 1rem;
 }
@@ -396,6 +421,14 @@ main p + p {
 
   .hero {
     text-align: left;
+  }
+
+  .brand-logo {
+    height: 44px;
+  }
+
+  .hero-logo {
+    width: 64px;
   }
 }
 


### PR DESCRIPTION
## Summary
- restyle the shared stylesheet around the #8DD50C LivingSimple palette and update buttons, forms, hero, and footer accents
- add SVG logo and favicon assets and surface them in the navigation, hero banner, and footer
- include theme-color metadata and the new favicon across every static page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8a2953e988322a32035251e451972