### PR TITLE
Update LivingSimple branding SVG assets

### DIFF
--- a/public/images/livingsimple-favicon.svg
+++ b/public/images/livingsimple-favicon.svg
@@ -1,14 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
-  <title id="title">LivingSimple Properties icon</title>
-  <circle cx="64" cy="64" r="58" fill="none" stroke="#8DD50C" stroke-width="10" />
-  <path
-    d="M64 22 100 44v48l-36 22-36-22V44Z"
-    fill="none"
-    stroke="#8DD50C"
-    stroke-width="10"
-    stroke-linejoin="round"
-  />
-  <rect x="50" y="50" width="28" height="28" fill="none" stroke="#8DD50C" stroke-width="8" />
-  <line x1="64" y1="50" x2="64" y2="78" stroke="#8DD50C" stroke-width="8" />
-  <line x1="50" y1="64" x2="78" y2="64" stroke="#8DD50C" stroke-width="8" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Living Simple icon</title>
+  <desc id="desc">Circular green emblem with a stylised house and four window panes</desc>
+  <defs>
+    <style>
+      .brand-green { fill: #8bd331; }
+      .brand-stroke { stroke: #8bd331; stroke-width: 36; fill: none; stroke-linejoin: round; }
+    </style>
+  </defs>
+  <circle class="brand-stroke" cx="256" cy="256" r="220" />
+  <path class="brand-green" d="M256 96 L392 196 V360 H328 V276 H184 V360 H120 V196 Z" />
+  <rect x="232" y="228" width="48" height="48" fill="#ffffff" opacity="0.92" />
+  <rect x="232" y="284" width="48" height="48" fill="#ffffff" opacity="0.92" />
+  <rect x="288" y="228" width="48" height="48" fill="#ffffff" opacity="0.92" />
+  <rect x="288" y="284" width="48" height="48" fill="#ffffff" opacity="0.92" />
+  <rect x="244" y="240" width="24" height="24" class="brand-green" />
+  <rect x="244" y="296" width="24" height="24" class="brand-green" />
+  <rect x="300" y="240" width="24" height="24" class="brand-green" />
+  <rect x="300" y="296" width="24" height="24" class="brand-green" />
 </svg>

--- a/public/images/livingsimple-logo.svg
+++ b/public/images/livingsimple-logo.svg
@@ -1,32 +1,30 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 160" role="img" aria-labelledby="title desc">
-  <title id="title">LivingSimple Properties logo</title>
-  <desc id="desc">A green house icon inside a circle with the words living simple properties.</desc>
-  <g transform="translate(10 10)">
-    <circle cx="80" cy="80" r="60" fill="none" stroke="#8DD50C" stroke-width="8" />
-    <path
-      d="M80 40l43 26v52l-43 26-43-26V66Z"
-      fill="none"
-      stroke="#8DD50C"
-      stroke-width="8"
-      stroke-linejoin="round"
-    />
-    <rect x="66" y="66" width="28" height="28" fill="none" stroke="#8DD50C" stroke-width="6" />
-    <line x1="80" y1="66" x2="80" y2="94" stroke="#8DD50C" stroke-width="6" />
-    <line x1="66" y1="80" x2="94" y2="80" stroke="#8DD50C" stroke-width="6" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 760" role="img" aria-labelledby="title desc">
+  <title id="title">Living Simple Properties logo</title>
+  <desc id="desc">Bright green outlined house emblem with the words living simple properties</desc>
+  <defs>
+    <style>
+      .brand-green { fill: #8bd331; }
+      .brand-stroke { stroke: #8bd331; stroke-width: 32; fill: none; stroke-linejoin: round; }
+      .word-grey { fill: #6d6e71; font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif; font-size: 170px; font-weight: 500; letter-spacing: -2px; }
+      .word-black { fill: #3d3d3d; font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif; font-size: 170px; font-weight: 700; letter-spacing: -2px; }
+      .tagline { fill: #6d6e71; font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif; font-size: 80px; font-weight: 400; letter-spacing: 50px; text-transform: uppercase; }
+    </style>
+  </defs>
+  <g transform="translate(60 60)">
+    <circle class="brand-stroke" cx="210" cy="220" r="195" />
+    <path class="brand-green" d="M210 80 L344 180 V340 H276 V258 H144 V340 H76 V180 Z" />
+    <rect x="190" y="204" width="40" height="40" fill="#fff" opacity="0.9" />
+    <rect x="190" y="256" width="40" height="40" fill="#fff" opacity="0.9" />
+    <rect x="242" y="204" width="40" height="40" fill="#fff" opacity="0.9" />
+    <rect x="242" y="256" width="40" height="40" fill="#fff" opacity="0.9" />
+    <rect x="198" y="212" width="24" height="24" fill="#8bd331" />
+    <rect x="198" y="268" width="24" height="24" fill="#8bd331" />
+    <rect x="254" y="212" width="24" height="24" fill="#8bd331" />
+    <rect x="254" y="268" width="24" height="24" fill="#8bd331" />
   </g>
-  <text x="170" y="92" font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="42">
-    <tspan fill="#5f5f5f" font-weight="400">living</tspan>
-    <tspan dx="14" fill="#202020" font-weight="700">simple</tspan>
-  </text>
-  <text
-    x="170"
-    y="126"
-    font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif"
-    font-size="16"
-    font-weight="600"
-    letter-spacing="0.45em"
-    fill="#5f5f5f"
-  >
-    PROPERTIES
-  </text>
+  <g transform="translate(420 250)">
+    <text class="word-grey" x="0" y="120">living</text>
+    <text class="word-black" x="320" y="120">simple</text>
+  </g>
+  <text class="tagline" x="120" y="660">PROPERTIES</text>
 </svg>


### PR DESCRIPTION
## Summary
- replace the Living Simple logo SVG with the refreshed house emblem and typography
- update the favicon SVG so it matches the new branding icon

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8b3d7d7008332b910bef855130e62