### PR TITLE
Add live reviews section and route ordering

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,9 +33,6 @@ const PORT = process.env.PORT || 3000;
 
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.use((req, res) => {
-  res.sendFile(path.join(__dirname, 'public', 'index.html'));
-});
 app.get("/api/reviews", async (req, res) => {
   try {
     // 1. Exchange refresh token for access token
@@ -63,6 +60,10 @@ app.get("/api/reviews", async (req, res) => {
     console.error(err);
     res.status(500).json({ error: "Failed to fetch reviews" });
   }
+});
+
+app.use((req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
 app.listen(PORT, () => {

--- a/public/index.html
+++ b/public/index.html
@@ -167,6 +167,7 @@
               <strong>Max J. · Gaithersburg – Google Business</strong>
             </article>
           </div>
+          <section id="reviews" class="live-reviews"></section>
         </div>
       </section>
 
@@ -260,6 +261,87 @@
   </div>
 </footer>
 
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const reviewsSection = document.getElementById("reviews");
+        if (!reviewsSection) {
+          return;
+        }
+
+        const placeholder = document.createElement("p");
+        placeholder.className = "reviews-placeholder";
+        placeholder.textContent = "⭐ Live Google reviews will appear here once approved.";
+        reviewsSection.appendChild(placeholder);
+
+        fetch("/api/reviews")
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error("Failed to load reviews");
+            }
+            return response.json();
+          })
+          .then((data) => {
+            const reviews = Array.isArray(data) ? data.slice(0, 5) : [];
+
+            if (!reviews.length) {
+              return;
+            }
+
+            reviewsSection.innerHTML = "";
+            const cards = document.createElement("div");
+            cards.className = "reviews-grid";
+
+            const ratingMap = {
+              ONE: 1,
+              TWO: 2,
+              THREE: 3,
+              FOUR: 4,
+              FIVE: 5,
+            };
+
+            reviews.forEach((review) => {
+              const card = document.createElement("article");
+              card.className = "review-card";
+
+              const author =
+                review?.reviewer?.displayName ||
+                review?.authorName ||
+                "Anonymous";
+              const starRating = ratingMap[review?.starRating] || review?.rating || 0;
+              const commentValue =
+                typeof review?.comment === "string"
+                  ? review.comment
+                  : review?.comment?.comment ||
+                    review?.text ||
+                    review?.reviewComment ||
+                    "";
+
+              const authorEl = document.createElement("strong");
+              authorEl.className = "review-author";
+              authorEl.textContent = author;
+
+              const starsEl = document.createElement("div");
+              starsEl.className = "review-stars";
+              const starCount = Math.max(0, Math.min(5, Math.round(starRating)));
+              starsEl.textContent = "★".repeat(starCount).padEnd(5, "☆");
+
+              const textEl = document.createElement("p");
+              textEl.className = "review-text";
+              textEl.textContent = commentValue || "No additional comments.";
+
+              card.appendChild(authorEl);
+              card.appendChild(starsEl);
+              card.appendChild(textEl);
+              cards.appendChild(card);
+            });
+
+            reviewsSection.appendChild(cards);
+          })
+          .catch((error) => {
+            console.error(error);
+          });
+      });
+    </script>
     <script src="script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the /api/reviews route is registered before the catch-all HTML handler so it returns JSON
- add a live reviews section placeholder beneath the testimonials and display a fallback message
- fetch recent Google reviews on page load and render up to five review cards with author, rating, and text

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8d4b5b8b48322bda93699195a7efa